### PR TITLE
Fix multiple save-as prompts

### DIFF
--- a/packages/ide/src/fill/dialog.ts
+++ b/packages/ide/src/fill/dialog.ts
@@ -131,7 +131,7 @@ export class Dialog {
 	 */
 	public show(): void {
 		if (document.querySelector(`.${this.overlay.className}`)) {
-			throw new Error ("Save prompt is already open");
+			throw new Error ("Overlay is already open");
 		}
 		if (!this.cachedActiveElement) {
 			this.cachedActiveElement = document.activeElement as HTMLElement;

--- a/packages/ide/src/fill/dialog.ts
+++ b/packages/ide/src/fill/dialog.ts
@@ -130,7 +130,7 @@ export class Dialog {
 	 * Show the dialog.
 	 */
 	public show(): void {
-		if (!this.cachedActiveElement) {
+		if (!this.cachedActiveElement && document.getElementsByClassName(this.overlay.className).length === 0) {
 			this.cachedActiveElement = document.activeElement as HTMLElement;
 			(document.querySelector(".monaco-workbench") || document.body).appendChild(this.overlay);
 			document.addEventListener("keydown", this.onKeydown);

--- a/packages/ide/src/fill/dialog.ts
+++ b/packages/ide/src/fill/dialog.ts
@@ -130,7 +130,10 @@ export class Dialog {
 	 * Show the dialog.
 	 */
 	public show(): void {
-		if (!this.cachedActiveElement && document.getElementsByClassName(this.overlay.className).length === 0) {
+		if (document.querySelector(`.${this.overlay.className}`)) {
+			throw new Error ("Save prompt is already open");
+		}
+		if (!this.cachedActiveElement) {
 			this.cachedActiveElement = document.activeElement as HTMLElement;
 			(document.querySelector(".monaco-workbench") || document.body).appendChild(this.overlay);
 			document.addEventListener("keydown", this.onKeydown);


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it
The save as overlays open on top of each other if invoked before dismissing. This checks to see if there is an overlay present before spawning another one.

### Is there an open issue you can link to?
fixes #536
