### PR TITLE
Respect LD_LIBRARY_PATH when forking on Linux

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,5 +1,6 @@
 import { field, logger } from "@coder/logger";
 import { ServerMessage, SharedProcessActive } from "@coder/protocol/src/proto";
+import { preserveEnv } from "@coder/protocol";
 import { ChildProcess, fork, ForkOptions } from "child_process";
 import { randomFillSync } from "crypto";
 import * as fs from "fs";
@@ -174,17 +175,21 @@ const bold = (text: string | number): string | number => {
 	}
 
 	if (options.installExtension) {
+
+		let forkOptions = {
+			env: {
+				VSCODE_ALLOW_IO: "true"
+			}
+		}
+
+		preserveEnv(forkOptions);
+
 		const fork = forkModule("vs/code/node/cli", [
 			"--user-data-dir", dataDir,
 			"--builtin-extensions-dir", builtInExtensionsDir,
 			"--extensions-dir", extensionsDir,
 			"--install-extension", options.installExtension,
-		], {
-			env: {
-				VSCODE_ALLOW_IO: "true",
-				VSCODE_LOGS: process.env.VSCODE_LOGS,
-			},
-		}, dataDir);
+		], forkOptions, dataDir);
 
 		fork.stdout.on("data", (d: Buffer) => d.toString().split("\n").forEach((l) => logger.info(l)));
 		fork.stderr.on("data", (d: Buffer) => d.toString().split("\n").forEach((l) => logger.error(l)));

--- a/packages/server/src/vscode/sharedProcess.ts
+++ b/packages/server/src/vscode/sharedProcess.ts
@@ -7,6 +7,7 @@ import { ParsedArgs } from "vs/platform/environment/common/environment";
 import { Emitter } from "@coder/events/src";
 import { retry } from "@coder/ide/src/retry";
 import { logger, field, Level } from "@coder/logger";
+import { preserveEnv } from "@coder/protocol";
 
 export enum SharedProcessState {
 	Stopped,
@@ -88,13 +89,15 @@ export class SharedProcess {
 			this.activeProcess.kill();
 		}
 
-		const activeProcess = forkModule("vs/code/electron-browser/sharedProcess/sharedProcessMain", [], {
+		let forkOptions = {
 			env: {
-				VSCODE_ALLOW_IO: "true",
-				VSCODE_LOGS: process.env.VSCODE_LOGS,
-				DISABLE_TELEMETRY: process.env.DISABLE_TELEMETRY,
-			},
-		}, this.userDataDir);
+				VSCODE_ALLOW_IO: "true"
+			}
+		}
+
+		preserveEnv(forkOptions);
+
+		const activeProcess = forkModule("vs/code/electron-browser/sharedProcess/sharedProcessMain", [], forkOptions, this.userDataDir);
 		this.activeProcess = activeProcess;
 
 		await new Promise((resolve, reject): void => {


### PR DESCRIPTION
<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it
Currently there is no easy way to run `code-server` if disto's "stock" `libstdc++` package is too old because `code-server`  does not respect `LD_LIBRARY_PATH` on Linux.

Even if I set `LD_LIBRARY_PATH` I get this error:
```
...
INFO  Starting shared process [1/5]...
WARN  stderr {"data":"/export/home/fedor.kalugin/cli-linux-x64: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /export/home/fedor.kalugin/cli-linux-x64)\n/export/home/fedor.kalugin/cli-linux-x64: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required
by /export/home/fedor.kalugin/cli-linux-x64)\n/export/home/fedor.kalugin/cli-linux-x64: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found
(required by /export/home/fedor.kalugin/cli-linux-x64)\n"}
INFO  Starting shared process [2/5]... {"error":"Exited with 1"}
...
```

In some environments there is newer `libstdc++` available that isn't installed to default location. This Pull Request makes it possible to use custom `libstdc++`.

### Is there an open issue you can link to?

#347
#239
