### PR TITLE
Show files that start with "." in open dialog

### DIFF
--- a/packages/vscode/src/fill/windowsService.ts
+++ b/packages/vscode/src/fill/windowsService.ts
@@ -70,6 +70,7 @@ export class WindowsService implements IWindowsService {
 		showOpenDialog({
 			...(options.dialogOptions || {}),
 			properties: {
+				showHiddenFiles: true,
 				openFile: true,
 			},
 		}).then((path) => {


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it
Files like `.gitignore` wouldn't show up in the open file dialog. This PR fixes that.

### Is there an open issue you can link to?
fixes #603
