### PR TITLE
GH-673: Revert "Remove chmod on project dir"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN mkdir -p /home/coder/project && \
 WORKDIR /home/coder/project
 
 # This assures we have a volume mounted even if the user forgot to do bind mount.
-# XXX: Workaround for GH-459 and for OpenShift compatibility.
+# So that they do not lose their data if they delete the container.
 VOLUME [ "/home/coder/project" ]
 
 COPY --from=0 /src/packages/server/cli-linux-x64 /usr/local/bin/code-server

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,13 @@ RUN adduser --gecos '' --disabled-password coder && \
 
 USER coder
 # We create first instead of just using WORKDIR as when WORKDIR creates, the user is root.
-RUN mkdir -p /home/coder/project
+RUN mkdir -p /home/coder/project && \
+    chmod g+rw /home/coder/project;
 
 WORKDIR /home/coder/project
 
 # This assures we have a volume mounted even if the user forgot to do bind mount.
-# So that they do not lose their data if they delete the container.
+# XXX: Workaround for GH-459 and for OpenShift compatibility.
 VOLUME [ "/home/coder/project" ]
 
 COPY --from=0 /src/packages/server/cli-linux-x64 /usr/local/bin/code-server


### PR DESCRIPTION


### Describe in detail the problem you had and how this PR fixes it

Due to the decision to remove the mode change, this inherently
reintroduced a bug that prevents the system to write to the bind
mounted folder. the chmod is intended to *fix* it.

### Is there an open issue you can link to?

this fixes GH-673
