### PR TITLE
Set NODE_ENV and VERSION when building

### DIFF
--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -1,4 +1,5 @@
 import { register, run } from "@coder/runner";
+import { logger, field } from "@coder/logger";
 import * as fs from "fs";
 import * as fse from "fs-extra";
 import * as os from "os";
@@ -17,6 +18,11 @@ const vscodeVersion = process.env.VSCODE_VERSION || "1.33.1";
 const vsSourceUrl = `https://codesrv-ci.cdr.sh/vstar-${vscodeVersion}.tar.gz`;
 
 const buildServerBinary = register("build:server:binary", async (runner) => {
+	logger.info("Building with environment", field("env", {
+		NODE_ENV: process.env.NODE_ENV,
+		VERSION: process.env.VERSION,
+	}));
+
 	await ensureInstalled();
 	await Promise.all([
 		buildBootstrapFork(),

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,13 +15,13 @@ function docker_build() {
 	docker cp ./. $containerID:/src
 	exec "cd /src && yarn"
 	exec "cd /src && npm rebuild"
-	exec "cd /src && yarn task build:server:binary"
+	exec "cd /src && NODE_ENV=production VERSION=$VERSION yarn task build:server:binary"
 	exec "cd /src && yarn task package $VERSION"
 	docker cp $containerID:/src/release/. ./release/
 }
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-	yarn task build:server:binary
+	NODE_ENV=production yarn task build:server:binary
 else
 	if [[ "$TARGET" == "alpine" ]]; then
 		IMAGE="codercom/nbin-alpine"


### PR DESCRIPTION
Should fix the version flag not reporting correctly as well as enable
the service worker and prevent the 404 hmr requests again.

Fixes #699.