### PR TITLE
Fix typos in wget url

### DIFF
--- a/doc/admin/install/aws.md
+++ b/doc/admin/install/aws.md
@@ -39,15 +39,15 @@ If you're just starting out, we recommend [installing code-server locally](../..
   ```
 - Replace {version} in the following command with the version found on the releases page and run it (or just copy the download URL from the releases page):
   ```
-  wget https://github.com/cdr/code-server/releases/download/{version}/code-server-{version}-linux-x64.tar.gz
+  wget https://github.com/cdr/code-server/releases/download/{version}/code-server{version}-linux-x64.tar.gz
   ```
 - Extract the downloaded tar.gz file with this command, for example:
   ```
-  tar -xvzf code-server-{version}-linux-x64.tar.gz
+  tar -xvzf code-server{version}-linux-x64.tar.gz
   ```
 - Navigate to extracted directory with this command:
   ```
-  cd code-server-{version}-linux-x64
+  cd code-server{version}-linux-x64
   ```
 - If you run into any permission errors, make the binary executable by running:
   ```

--- a/doc/admin/install/digitalocean.md
+++ b/doc/admin/install/digitalocean.md
@@ -22,15 +22,15 @@ If you're just starting out, we recommend [installing code-server locally](../..
   ```
 - Replace {version} in the following command with the version found on the releases page and run it (or just copy the download URL from the releases page):
   ```
-  wget https://github.com/cdr/code-server/releases/download/{version}/code-server-{version}-linux-x64.tar.gz
+  wget https://github.com/cdr/code-server/releases/download/{version}/code-server{version}-linux-x64.tar.gz
   ```
 - Extract the downloaded tar.gz file with this command, for example:
   ```
-  tar -xvzf code-server-{version}-linux-x64.tar.gz
+  tar -xvzf code-server{version}-linux-x64.tar.gz
   ```
 - Navigate to extracted directory with this command:
   ```
-  cd code-server-{version}-linux-x64
+  cd code-server{version}-linux-x64
   ```
 - If you run into any permission errors when attempting to run the binary:
   ```

--- a/doc/admin/install/google_cloud.md
+++ b/doc/admin/install/google_cloud.md
@@ -32,17 +32,17 @@ https://github.com/cdr/code-server/releases/latest
 
 - Replace {version} in the following command with the version found on the releases page and run it (or just copy the download URL from the releases page):
 ```
-wget https://github.com/cdr/code-server/releases/download/{version}/code-server-{version}-linux-x64.tar.gz
+wget https://github.com/cdr/code-server/releases/download/{version}/code-server{version}-linux-x64.tar.gz
 ```
 
 - Extract the downloaded tar.gz file with this command, for example:
 ```
-tar -xvzf code-server-{version}-linux-x64.tar.gz
+tar -xvzf code-server{version}-linux-x64.tar.gz
 ```
 
 - Navigate to extracted directory with this command:
 ```
-cd code-server-{version}-linux-x64
+cd code-server{version}-linux-x64
 ```
 
 - Make the binary executable if you run into any errors regarding permission:


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it
In url specified by `wget`, there are unnecessary `-`s.

### Is there an open issue you can link to?
Unsure.
