### PR TITLE
Add port to redirect URL when server port is 80

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -273,6 +273,7 @@ const bold = (text: string | number): string | number => {
 			},
 		},
 		password,
+		port,
 		httpsOptions: hasCustomHttps ? {
 			key: certKeyData,
 			cert: certData,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -28,6 +28,7 @@ interface CreateAppOptions {
 	registerMiddleware?: (app: express.Application) => void;
 	serverOptions?: ServerOptions;
 	password?: string;
+	port?: number;
 	httpsOptions?: https.ServerOptions;
 	allowHttp?: boolean;
 	bypassAuth?: boolean;
@@ -197,6 +198,12 @@ export const createApp = async (options: CreateAppOptions): Promise<{
 	): void => {
 		const currentUrl = `${protocol}://${req.headers.host}${req.originalUrl}`;
 		const newUrl = url.parse(currentUrl);
+		if (newUrl.port == null && options.port === 80) {
+			// Fix for https redirect on default port. The redirect would go to a URL without a port, so the
+			// browser would assume that it's redirecting to port 443.
+			newUrl.host += `:${options.port}`;
+			newUrl.port = "" + options.port;
+		}
 		if (from && newUrl.pathname) {
 			newUrl.pathname = newUrl.pathname.replace(new RegExp(`\/${from}\/?$`), "/");
 		}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -198,7 +198,7 @@ export const createApp = async (options: CreateAppOptions): Promise<{
 	): void => {
 		const currentUrl = `${protocol}://${req.headers.host}${req.originalUrl}`;
 		const newUrl = url.parse(currentUrl);
-		if (newUrl.port == null && options.port === 80) {
+		if (newUrl.port == null && protocol === "https" && options.port === 80) {
 			// Fix for https redirect on default port. The redirect would go to a URL without a port, so the
 			// browser would assume that it's redirecting to port 443.
 			newUrl.host += `:${options.port}`;


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it

This fixes HTTP to HTTPS redirects when people are running code-server on port 80 (default HTTP port).

Essentially, if code-server's port is 80 and is accessed over HTTP, code-server would redirect to HTTPS without adding `:80` to the end of the URL, resulting in the browser accessing over port 443.

I'm hesitant about this PR as it could cause problems with reverse proxies but unable to try multiple reverse proxy scenarios. **I don't think this should be merged until reverse proxies are tested and everything works as expected.**

### Is there an open issue you can link to?

#737

I've made another PR for changing the documentation that lead the user in the above issue to using port 80: #740