### PR TITLE
Support opening multi-folder workspaces

### DIFF
--- a/packages/vscode/src/workbench.ts
+++ b/packages/vscode/src/workbench.ts
@@ -213,7 +213,7 @@ export class Workbench {
 			let wid: IWorkspaceIdentifier = (<any>Object).assign({}, workspace);
 			if (!URI.isUri(wid.configPath)) {
 				// Ensure that the configPath is a valid URI.
-				wid.configPath = URI.file(wid.configPath);
+				wid.configPath = URI.file(wid.configPath.path);
 			}
 			config.workspace = wid;
 		} else {


### PR DESCRIPTION
<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it

A workspace is described by a JSON file named *.code-workspace in Visual Studio Code.  Therefore, code-server should let the user select a file for the "Open Workspace" action.

Also, fix a bug in `workbench` that `URI.file()` can only accept a string of path, not a raw dump instance of URI object.

### Is there an open issue you can link to?

https://github.com/cdr/code-server/issues/490