### PR TITLE
Use port from server.address() when printing the URL

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -279,10 +279,11 @@ const bold = (text: string | number): string | number => {
 		} : undefined,
 	});
 
-	logger.info("Starting webserver...", field("host", options.host), field("port", options.port));
 	if (options.socket) {
+		logger.info("Starting webserver via socket...", field("socket", options.socket));
 		app.server.listen(options.socket);
 	} else {
+		logger.info("Starting webserver...", field("host", options.host), field("port", options.port));
 		app.server.listen(options.port, options.host);
 	}
 	let clientId = 1;
@@ -323,14 +324,20 @@ const bold = (text: string | number): string | number => {
 		logger.warn("Launched without authentication.");
 	}
 	if (options.disableTelemetry) {
-		logger.info("Telemetry is disabled");
+		logger.info(" ");
+		logger.info("Telemetry is disabled.");
 	}
 
-	const protocol = options.allowHttp ? "http" : "https";
-	const url = `${protocol}://localhost:${options.port}/`;
 	logger.info(" ");
-	logger.info("Started (click the link below to open):");
-	logger.info(url);
+	if (options.socket) {
+		logger.info("Started on socket address:");
+		logger.info(options.socket);
+	} else {
+		const protocol = options.allowHttp ? "http" : "https";
+		const url = `${protocol}://localhost:${app.server.address().port}/`;
+		logger.info("Started (click the link below to open):");
+		logger.info(url);
+	}
 	logger.info(" ");
 
 	if (options.open) {


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it

When using port 0 on code-server, instead of printing the randomly generated port it will print URLs with port 0. This fixes that by getting the port from the server when printing the URL.

There are also some logging consistency changes in there as well, as HTTP messages were being printed even if sockets were being used.

### Is there an open issue you can link to?

Closes #779.