### PR TITLE
Added --whitespace=fix to git apply execution 

### DIFF
--- a/build/tasks.ts
+++ b/build/tasks.ts
@@ -176,7 +176,7 @@ const ensurePatched = register("vscode:patch", async (runner) => {
 
 	runner.cwd = vscodePath;
 	const patchPath = path.join(__dirname, "../scripts/vscode.patch");
-	const apply = await runner.execute("git", ["apply", "--unidiff-zero", patchPath]);
+	const apply = await runner.execute("git", ["apply", "--unidiff-zero", "--whitespace=fix", patchPath]);
 	if (apply.exitCode !== 0) {
 		throw new Error(`Failed to apply patches: ${apply.stderr}`);
 	}


### PR DESCRIPTION
In order to prevent trailing whitespace errors on Windows.

### Describe in detail the problem you had and how this PR fixes it
When running `docker build .` on **Windows**, I got a "trailing whitespace" error.

@deansheather suggested adding `--whitespace=fix` to the git apply execution, and it fixed the issue.

### Is there an open issue you can link to?
https://github.com/cdr/code-server/issues/805
