### PR TITLE
Update READE to add know issue for golang debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ How to [secure your setup](/doc/security/ssl.md).
 ### Known Issues
 
 - Creating custom VS Code extensions and debugging them doesn't work.
+- To debug Golang using [ms-vscode-go extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode.Go), you need to add `--security-opt seccomp=unconfined` to your `docker run` arguments when launching code-server with Docker. See [#725](https://github.com/cdr/code-server/issues/725) for details.
 
 ### Future
 - **Stay up to date!** Get notified about new releases of code-server.


### PR DESCRIPTION
<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it

This is a doc change to provide way to debug golang code using Go extension w/ code-server. Additional option is required when launch the code-server image.

### Is there an open issue you can link to?

#725 
