### PR TITLE
Add `use-credentials` to fetch manifest with cookies

### DIFF
--- a/scripts/webpack.client.config.js
+++ b/scripts/webpack.client.config.js
@@ -61,6 +61,7 @@ module.exports = (options = {}) => merge(
 			short_name: "Coder",
 			description: "Run VS Code on a remote server",
 			background_color: "#e5e5e5",
+			crossorigin: 'use-credentials',
 			icons: [{
 				src: path.join(root, "packages/web/assets/logo.png"),
 				sizes: [96, 128, 192, 256, 384],

--- a/scripts/webpack.client.config.js
+++ b/scripts/webpack.client.config.js
@@ -61,7 +61,7 @@ module.exports = (options = {}) => merge(
 			short_name: "Coder",
 			description: "Run VS Code on a remote server",
 			background_color: "#e5e5e5",
-			crossorigin: 'use-credentials',
+			crossorigin: "use-credentials",
 			icons: [{
 				src: path.join(root, "packages/web/assets/logo.png"),
 				sizes: [96, 128, 192, 256, 384],


### PR DESCRIPTION


<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it

I run code-server behind an authenticating Kubernetes Ingress which sets a cookie after a successful login is performed. Since this cookie is not set when fetching the manifest, the fetch fails and gets redirected to the authentication page, breaking code-server completely.

Adding this attribute to the link tag causes browsers to fetch the manifest including cookies previously set. See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link for more information.

### Is there an open issue you can link to?

#822 