### PR TITLE
Fix self-hosted documentation screenshot URL

### DIFF
--- a/doc/self-hosted/index.md
+++ b/doc/self-hosted/index.md
@@ -25,7 +25,7 @@ It takes just a few minutes to get your own self-hosted server running. If you'v
 > NOTE: Be careful with your password as sharing it will grant those users access to your server's file system
 
 ### Things To Know
-- When you visit the IP for your code-server instance, you will be greeted with a page similar to the following screenshot. Code-server is using a self-signed SSL certificate for easy setup. In Chrome/Chromium, click **"Advanced"** then click **"proceed anyway"**. In Firefox, click **Advanced**, then **Add Exception**, then finally **Confirm Security Exception**.<img src ="../../assets/chrome_warning.png">
+- When you visit the IP for your code-server instance, you will be greeted with a page similar to the following screenshot. Code-server is using a self-signed SSL certificate for easy setup. In Chrome/Chromium, click **"Advanced"** then click **"proceed anyway"**. In Firefox, click **Advanced**, then **Add Exception**, then finally **Confirm Security Exception**.<img src ="../assets/chrome_warning.png">
 
 ## Usage
 <pre class="pre-wrap"><code>code-server<span class="virtual-br"></span> --help</code></pre>


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it

Fixes the screenshot URL in the self-hosted documentation.