### PR TITLE
Change Fetch for onigasm to use credentials

### DIFF
--- a/packages/vscode/src/fill/vscodeTextmate.ts
+++ b/packages/vscode/src/fill/vscodeTextmate.ts
@@ -22,7 +22,7 @@ target.Registry = class Registry extends vscodeTextmate.Registry {
 					const onigasm = require("onigasm");
 					const wasmUrl = require("!!file-loader!onigasm/lib/onigasm.wasm");
 
-					return fetch(wasmUrl).then(resp => resp.arrayBuffer()).then(buffer => {
+					return fetch(wasmUrl, {credentials: 'same-origin'}).then(resp => resp.arrayBuffer()).then(buffer => {
 						return onigasm.loadWASM(buffer);
 					}).then(() => {
 						res({


### PR DESCRIPTION
will cause credentials to be used to fetch onigasm so that it will work behind a proxy that is validating client certificates. 

Issue:
fetching .wasm does not work behind proxy #845

