### PR TITLE
Modify webpack-pwa-manifest config to support iOS icon

### DIFF
--- a/scripts/webpack.client.config.js
+++ b/scripts/webpack.client.config.js
@@ -65,7 +65,10 @@ module.exports = (options = {}) => merge(
 			icons: [{
 				src: path.join(root, "packages/web/assets/logo.png"),
 				sizes: [96, 128, 192, 256, 384],
+				ios: true
 			}],
+			inject: true,
+			ios: true
 		})
 	].concat(prod ? [
 		new GenerateSW({


### PR DESCRIPTION
### Describe in detail the problem you had and how this PR fixes it
The auto-generated icon for Code Server on iPad and other iOS devices was partially broken and unreadable. This change makes use of the existing support in webpack-pwa-manifest to assign the real app icon to the appropriate meta tag in the app HTML file.

### Is there an open issue you can link to?
https://github.com/cdr/code-server/issues/802