### PR TITLE
fix: vscode.window.state in extHost always false

### DIFF
--- a/packages/vscode/src/fill/windowsService.ts
+++ b/packages/vscode/src/fill/windowsService.ts
@@ -46,6 +46,15 @@ export class WindowsService implements IWindowsService {
 
 	private readonly window = new electron.BrowserWindow();
 
+	constructor() {
+		window.addEventListener("focus", () => {
+			this.focusEmitter.emit(workbench.windowId);
+		});
+		window.addEventListener("blur", () => {
+			this.blurEmitter.emit(workbench.windowId);
+		});
+	}
+
 	// Dialogs
 	public async pickFileFolderAndOpen(options: INativeOpenDialogOptions): Promise<void> {
 		showOpenDialog({


### PR DESCRIPTION
## Problem

I've an extension which rely on this `vscode.window.onDidChangeWindowState` extHost api, but since code-server did not implemented the `focus` and `blur` events in the custom `windowsService`, my extension doesn't work in the code-server. So I make this fix and it works.