### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ docker run -it -p 127.0.0.1:8443:8443 -v "${PWD}:/home/coder/project" codercom/c
 
 [![Create a Droplet](./doc/assets/do-new-droplet-btn.svg)](https://marketplace.digitalocean.com/apps/code-server?action=deploy)
 
+[![Deploy](https://raw.githubusercontent.com/mastappl/images/master/deployTo.png)](https://panel.d2c.io/?import=https://github.com/d2cio/code-server-stack/archive/master.zip/)
+
 ### Run over SSH
 
 Use [sshcode](https://github.com/codercom/sshcode) for a simple setup.


### PR DESCRIPTION
D2C helps to deploy code-server to any cloud host on supported providers (DO, AWS, GCP, Vultr, UpCloud) or on own connected host with a singe-click. 
The deployment available with our free plan, so a user pays only for a host. It gives much more opportunity to deploy your solution to almost any host :) 
Check out the stack repo with a demo - https://github.com/d2cio/code-server-stack

