### PR TITLE
Update password stored as a SHA256 hash in cookie

### DIFF
--- a/packages/app/browser/src/app.ts
+++ b/packages/app/browser/src/app.ts
@@ -2,6 +2,7 @@
 import { MDCTextField } from "@material/textfield";
 //@ts-ignore
 import { MDCCheckbox } from "@material/checkbox";
+import { createHash } from "crypto";
 import "material-components-web/dist/material-components-web.css";
 import "./app.scss";
 
@@ -26,9 +27,13 @@ if (!form) {
 	throw new Error("No password form found");
 }
 
+const hash = (guid: string): string => {
+	return createHash("sha256").update(guid).digest("hex");
+};
+
 form.addEventListener("submit", (e) => {
 	e.preventDefault();
-	document.cookie = `password=${password.value}; `
+	document.cookie = `password=${hash(password.value)}; `
 		+ `path=${location.pathname.replace(/\/login\/?$/, "/")}; `
 		+ `domain=${location.hostname}`;
 	location.reload();

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -22,6 +22,7 @@ import * as url from "url";
 import * as ws from "ws";
 import { buildDir } from "./constants";
 import { createPortScanner } from "./portScanner";
+import { createHash } from "crypto";
 import safeCompare = require("safe-compare");
 
 interface CreateAppOptions {
@@ -87,7 +88,7 @@ export const createApp = async (options: CreateAppOptions): Promise<{
 			// Try/catch placed here just in case
 			const cookies = parseCookies(req);
 			if (cookies.password) {
-				if (!safeCompare(cookies.password, options.password)) {
+				if (!safeCompare(cookies.password, hash(options.password))) {
 					let userAgent = req.headers["user-agent"];
 					let timestamp = Math.floor(new Date().getTime() / 1000);
 					if (Array.isArray(userAgent)) {
@@ -118,6 +119,10 @@ export const createApp = async (options: CreateAppOptions): Promise<{
 
 		// tslint:disable-next-line:no-any
 		return (socket as any).encrypted;
+	};
+
+	const hash = (guid: string): string => {
+		return createHash("sha256").update(guid).digest("hex");
 	};
 
 	const app = express();


### PR DESCRIPTION
<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it
The authentication password is stored in _plain-text_ in a cookie named _password_. 

Some may not see this as a security issue for _automatically generated passwords_ (although bad practice) but it is definitively an issue when setting a _custom password_.

Therefore switching from a plain-text stored password to a SHA256 hash is a _quick first step_ in the right direction (aka. I agree it could be better, eg. salted hash).

I saw that there are pull requests providing other solutions (eg. #931 ) for authentication methods which were blocked by [GH-857](https://github.com/cdr/code-server/pull/857), but really think this pull request should be merged in for the next v1 release.

![code-server-password-hash-poc](https://user-images.githubusercontent.com/8902761/64306977-ce042b80-cf94-11e9-8ad6-5c95fcfa648a.png)

### Is there an open issue you can link to?
Issue #515 (Issue #565)

