### PR TITLE
[README] Add volume flag for persisting configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Try it out:
 ```bash
-docker run -it -p 127.0.0.1:8443:8443 -v "${PWD}:/home/coder/project" codercom/code-server --allow-http --no-auth
+docker run -it -p 127.0.0.1:8443:8443 -v "${HOME}/.local/share/code-server:/home/coder/.local/share/code-server" -v "${PWD}:/home/coder/project" codercom/code-server --allow-http --no-auth
 ```
 
 - Code on your Chromebook, tablet, and laptop with a consistent dev environment.


### PR DESCRIPTION
This adds a flag within the README command so people have an idea how to persist code-server settings in Docker.

Fixes GH-965

