### PR TITLE
[doc/self-hosted] make XFO same origin in docs

### DIFF
--- a/doc/self-hosted/index.md
+++ b/doc/self-hosted/index.md
@@ -148,7 +148,7 @@ server {
   # real_ip_header CF-Connecting-IP;
 
   # Other security options.
-  add_header X-Frame-Options DENY;
+  add_header X-Frame-Options SAMEORIGIN;
   add_header X-Content-Type-Options nosniff;
   add_header X-XSS-Protection "1; mode=block";
 


### PR DESCRIPTION
As reported in GH-962, this breaks VSCode's extension details view. Might need further triage if its also a v2 internal issue.
