### PR TITLE
Update server.ts

### DIFF
--- a/src/node/server.ts
+++ b/src/node/server.ts
@@ -298,7 +298,10 @@ export abstract class Server {
 						return response;
 				}
 				if (!this.authenticate(request)) {
-					return { redirect: "/login" };
+					return { 
+			   			redirect: "/login",
+			   			headers: { "Set-Cookie": `password=` }
+			   		};
 				}
 				break;
 			case "/static":


### PR DESCRIPTION
Change to avoid endless redirect whenever the password changes, while the old password is still set in a cookie.

<!-- Please answer these questions before submitting your PR. Thanks! -->

### Describe in detail the problem you had and how this PR fixes it
Originally ran the container with a self generated password, which was accepted and recorded as a cookie. Updated the docker to use a custom password and a site started generating endless redirects between a home and a login directories, this has occurred due to an inability to clear the wrong password from memory.

### Is there an open issue you can link to?
Somewhat related, error #1117
