### PR TITLE
Update Dockerfile to fix EACCES issue on mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ USER coder
 # We create first instead of just using WORKDIR as when WORKDIR creates, the
 # user is root.
 RUN mkdir -p /home/coder/project
+# To avoid EACCES issues on f.ex Crostini (ChromeOS)
+RUN mkdir -p /home/coder/.local/code-server
 
 WORKDIR /home/coder/project
 


### PR DESCRIPTION
Fixes #1188 
Fixes issue with permissions mounting in directories in the container. Folders are generated by root causing issues when the container user "coder" wants to create sub-folders. This fix solves it, at least on Crostini (ChromeOS)
