### PR TITLE
Update the manifest start_url to point at index

### DIFF
--- a/src/media/manifest.json
+++ b/src/media/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "code-server",
 	"short_name": "code-server",
-	"start_url": ".",
+	"start_url": "/",
 	"display": "standalone",
 	"background-color": "#fff",
 	"description": "Run VS Code on a remote server.",


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/Manifest/start_url#Relative_URL

the start_url, if a relative URL like '.', should point to a path relative to the manifest.

After testing the install in Samsung Internet, this results in a broken link because it points to the folder containing the manifest:

`localhost:8080/static-336ee288886f5728e1191e9ada2aeba5eb0bbd76/out/vs/server/src/media/`

Which is the correct behaviour, but the expected behaviour is that it points to the root of the project.

An alternative change would be to: `../../../../../../`

### Describe in detail the problem you had and how this PR fixes it

After using `add to homescreen` in Samsung Internet on Android the window is pointing at the wrong path.

This fixes the issue by pointing to '/' instead of the manifest location '.'

![image](https://user-images.githubusercontent.com/4225330/72258299-9a51a600-3605-11ea-9e72-ce6aaf6aaea1.png)