### PR TITLE
scripts/build: ditch -vsc suffix

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -79,7 +79,7 @@ class Builder {
 
 		const vscodeSourcePath = path.join(this.outPath, "source", `vscode-${vscodeVersion}-source`);
 		const binariesPath = path.join(this.outPath, "binaries");
-		const binaryName = `code-server${codeServerVersion}-${target}-${arch}`;
+		const binaryName = `code-server-${codeServerVersion}-${target}-${arch}`;
 		const finalBuildPath = path.join(this.outPath, "build", `${binaryName}-built`);
 
 		switch (task) {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -231,7 +231,7 @@ class Builder {
 
 			const [productJson, packageJson] = await Promise.all([
 				merge("product", { commit, date }),
-				merge("package", { codeServerVersion: codeServerVersion }),
+				merge("package", { codeServerVersion }),
 			]);
 
 			// We could do this before the optimization but then it'd be copied into

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -79,7 +79,7 @@ class Builder {
 
 		const vscodeSourcePath = path.join(this.outPath, "source", `vscode-${vscodeVersion}-source`);
 		const binariesPath = path.join(this.outPath, "binaries");
-		const binaryName = `code-server${codeServerVersion}-vsc${vscodeVersion}-${target}-${arch}`;
+		const binaryName = `code-server${codeServerVersion}-${target}-${arch}`;
 		const finalBuildPath = path.join(this.outPath, "build", `${binaryName}-built`);
 
 		switch (task) {
@@ -231,7 +231,7 @@ class Builder {
 
 			const [productJson, packageJson] = await Promise.all([
 				merge("product", { commit, date }),
-				merge("package", { codeServerVersion: `${codeServerVersion}-vsc${vscodeVersion}` }),
+				merge("package", { codeServerVersion: codeServerVersion }),
 			]);
 
 			// We could do this before the optimization but then it'd be copied into

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,7 +11,9 @@ main() {
 	version=$(./binaries/code-server* --version | head -1)
 	echo "Got '$version' for the version"
 	case $version in
-		*-vsc1.41.1) exit 0 ;;
+	    # FIXME: this isn't semver compliant yet but its based on what our latest tag is!
+		*[0123456789].+[0123456789]) exit 0 ;;
+		*daily) echo "Assuming test builds, exiting."; exit 0 ;; 
 		*) exit 1 ;;
 	esac
 }


### PR DESCRIPTION
This would fix some automation systems since keeping the vsc suffix with our new tag deployment system breaks some of the CIs most people use.


This should reproduce quite predictable builds like we did previously.

![image](https://user-images.githubusercontent.com/14976516/73272199-f549e680-421c-11ea-9ada-2d31a840521c.png)

This compliments GH-1303.
