### PR TITLE
Reflect new location of vscodeVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ before building.
 
 ```shell
 export OUT=/path/to/output/build                 # Optional if only building. Required if also developing.
-yarn build $vscodeVersion $codeServerVersion     # See travis.yml for the VS Code version to use.
+yarn build $vscodeVersion $codeServerVersion     # See scripts/ci.bash for the VS Code version to use.
                                                  # The code-server version can be anything you want.
 node /path/to/output/build/out/vs/server/main.js # You can run the built JavaScript with Node.
 yarn binary $vscodeVersion $codeServerVersion    # Or you can package it into a binary.
@@ -141,7 +141,7 @@ before developing.
 ```shell
 git clone https://github.com/microsoft/vscode
 cd vscode
-git checkout ${vscodeVersion} # See travis.yml for the version to use.
+git checkout ${vscodeVersion} # See scripts/ci.bash for the version to use.
 yarn
 git clone https://github.com/cdr/code-server src/vs/server
 cd src/vs/server


### PR DESCRIPTION
The build instructions on `README.md` referred to the wrong place to find the VS Code Version.
