### PR TITLE
verb agreement typo in FAQ

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -30,7 +30,7 @@ copy it to the extensions folder.
 
 VS Code Online is a closed source managed service by Microsoft and only runs on Azure.
 
-code-server is open source and can be freely ran on any machine.
+code-server is open source and can be freely run on any machine.
 
 ## How should I expose code-server to the internet?
 


### PR DESCRIPTION
dear owners,

this is a simple copy-editing pull request. The issue regards verb-agreement. In cases like this the past-participle, run, is the correct form. Thank you for your time, and thank you for your superb application.

all best,

Dr. Matthew Jeffrey Abrams

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.
-->
