### PR TITLE
HTTP proxy

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -83,7 +83,7 @@ Now you can browse to `<port>.coder.com`. Note that this uses the host header so
 ensure your reverse proxy forwards that information if you are using one.
 
 ### Sub-paths
-Just browse to `/proxy/<port>`.
+Just browse to `/proxy/<port>/`.
 
 ## x86 releases?
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -65,6 +65,26 @@ only to HTTP requests.
 You can use [Let's Encrypt](https://letsencrypt.org/) to get an SSL certificate
 for free.
 
+## How do I access web services?
+code-server is capable of proxying to any port using either a subdomain or a
+subpath.
+
+### Sub-domains
+Set up a wildcard certificate for your domain and a wildcard DNS entry (or you
+can configure each subdomain individually for the ports you expect to use).
+
+Start code-server with the `--proxy-domain` flag set to your domain.
+
+```
+code-server --proxy-domain coder.com
+```
+
+Now you can browse to `<port>.coder.com`. Note that this uses the host header so
+ensure your reverse proxy forwards that information if you are using one.
+
+### Sub-paths
+Just browse to `/proxy/<port>`.
+
 ## x86 releases?
 
 node has dropped support for x86 and so we decided to as well. See

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -65,23 +65,29 @@ only to HTTP requests.
 You can use [Let's Encrypt](https://letsencrypt.org/) to get an SSL certificate
 for free.
 
-## How do I access web services?
+## How do I securely access web services?
 
 code-server is capable of proxying to any port using either a subdomain or a
-subpath.
+subpath which means you can securely access these services using code-server's
+built-in authentication.
 
 ### Sub-domains
 
-Set up a wildcard certificate for your domain and a wildcard DNS entry (or you
-can configure each subdomain individually for the ports you expect to use).
+You will need a DNS entry that points to your server for each port you want to
+access. You can either set up a wildcard DNS entry for `*.<domain>` if your domain
+name registrar supports it or you can create one for every port you want to
+access (`3000.<domain>`, `8080.<domain>`, etc).
+
+You should also set up TLS certificates for these subdomains, either using a
+wildcard certificate for `*.<domain>` or individual certificates for each port.
 
 Start code-server with the `--proxy-domain` flag set to your domain.
 
 ```
-code-server --proxy-domain coder.com
+code-server --proxy-domain <domain>
 ```
 
-Now you can browse to `<port>.coder.com`. Note that this uses the host header so
+Now you can browse to `<port>.<domain>`. Note that this uses the host header so
 ensure your reverse proxy forwards that information if you are using one.
 
 ### Sub-paths

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -66,10 +66,12 @@ You can use [Let's Encrypt](https://letsencrypt.org/) to get an SSL certificate
 for free.
 
 ## How do I access web services?
+
 code-server is capable of proxying to any port using either a subdomain or a
 subpath.
 
 ### Sub-domains
+
 Set up a wildcard certificate for your domain and a wildcard DNS entry (or you
 can configure each subdomain individually for the ports you expect to use).
 
@@ -83,6 +85,7 @@ Now you can browse to `<port>.coder.com`. Note that this uses the host header so
 ensure your reverse proxy forwards that information if you are using one.
 
 ### Sub-paths
+
 Just browse to `/proxy/<port>/`.
 
 ## x86 releases?

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/adm-zip": "^0.4.32",
     "@types/fs-extra": "^8.0.1",
+    "@types/http-proxy": "^1.17.4",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.7",
     "@types/parcel-bundler": "^1.12.1",
@@ -52,13 +53,14 @@
     "@coder/logger": "1.1.11",
     "adm-zip": "^0.4.14",
     "fs-extra": "^8.1.0",
+    "http-proxy": "^1.18.0",
     "httpolyglot": "^0.1.2",
     "node-pty": "^0.9.0",
     "pem": "^1.14.2",
     "safe-compare": "^1.1.4",
     "semver": "^7.1.3",
-    "tar": "^6.0.1",
     "ssh2": "^0.8.7",
+    "tar": "^6.0.1",
     "tar-fs": "^2.0.0",
     "ws": "^7.2.0"
   }

--- a/src/browser/pages/home.html
+++ b/src/browser/pages/home.html
@@ -17,7 +17,7 @@
       href="{{BASE}}/static/{{COMMIT}}/src/browser/media/manifest.json"
       crossorigin="use-credentials"
     />
-    <link rel="apple-touch-icon" href="{{BASE}}/static/{{COMMIT}}/src/browser/media/pwa-icon-384.pnggg" />
+    <link rel="apple-touch-icon" href="{{BASE}}/static/{{COMMIT}}/src/browser/media/pwa-icon-384.png" />
     <link href="{{BASE}}/static/{{COMMIT}}/dist/pages/app.css" rel="stylesheet" />
     <meta id="coder-options" data-settings="{{OPTIONS}}" />
   </head>

--- a/src/node/app/api.ts
+++ b/src/node/app/api.ts
@@ -43,7 +43,8 @@ export class ApiHttpProvider extends HttpProvider {
 
   public async handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse> {
     this.ensureAuthenticated(request)
-    if (route.requestPath !== "/index.html") {
+    // Only serve root pages.
+    if (route.requestPath && route.requestPath !== "/index.html") {
       throw new HttpError("Not found", HttpCode.NotFound)
     }
 

--- a/src/node/app/api.ts
+++ b/src/node/app/api.ts
@@ -43,8 +43,7 @@ export class ApiHttpProvider extends HttpProvider {
 
   public async handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse> {
     this.ensureAuthenticated(request)
-    // Only serve root pages.
-    if (route.requestPath && route.requestPath !== "/index.html") {
+    if (!this.isRoot(route)) {
       throw new HttpError("Not found", HttpCode.NotFound)
     }
 

--- a/src/node/app/dashboard.ts
+++ b/src/node/app/dashboard.ts
@@ -20,7 +20,8 @@ export class DashboardHttpProvider extends HttpProvider {
   }
 
   public async handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse> {
-    if (route.requestPath !== "/index.html") {
+    // Only serve root pages.
+    if (route.requestPath && route.requestPath !== "/index.html") {
       throw new HttpError("Not found", HttpCode.NotFound)
     }
 

--- a/src/node/app/dashboard.ts
+++ b/src/node/app/dashboard.ts
@@ -20,8 +20,7 @@ export class DashboardHttpProvider extends HttpProvider {
   }
 
   public async handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse> {
-    // Only serve root pages.
-    if (route.requestPath && route.requestPath !== "/index.html") {
+    if (!this.isRoot(route)) {
       throw new HttpError("Not found", HttpCode.NotFound)
     }
 

--- a/src/node/app/login.ts
+++ b/src/node/app/login.ts
@@ -18,7 +18,8 @@ interface LoginPayload {
  */
 export class LoginHttpProvider extends HttpProvider {
   public async handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse> {
-    if (this.options.auth !== AuthType.Password || route.requestPath !== "/index.html") {
+    // Only serve root pages and only if password authentication is enabled.
+    if (this.options.auth !== AuthType.Password || (route.requestPath && route.requestPath !== "/index.html")) {
       throw new HttpError("Not found", HttpCode.NotFound)
     }
     switch (route.base) {

--- a/src/node/app/login.ts
+++ b/src/node/app/login.ts
@@ -18,8 +18,7 @@ interface LoginPayload {
  */
 export class LoginHttpProvider extends HttpProvider {
   public async handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse> {
-    // Only serve root pages and only if password authentication is enabled.
-    if (this.options.auth !== AuthType.Password || (route.requestPath && route.requestPath !== "/index.html")) {
+    if (this.options.auth !== AuthType.Password || !this.isRoot(route)) {
       throw new HttpError("Not found", HttpCode.NotFound)
     }
     switch (route.base) {

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -49,14 +49,14 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
     }
 
     // Ensure there is a trailing slash so relative paths work correctly.
-    const port = route.base.replace(/^\//, "")
-    const base = `${this.options.base}/${port}`
     if (this.isRoot(route) && !route.fullPath.endsWith("/")) {
       return {
-        redirect: `${base}/`,
+        redirect: `${route.fullPath}/`,
       }
     }
 
+    const port = route.base.replace(/^\//, "")
+    const base = `${this.options.base}/${port}`
     const payload = this.doProxy(route, request, response, port, base)
     if (payload) {
       return payload

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -168,15 +168,15 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
     // the event.
     ;(request as Request).base = base
 
-    const hxxp = response instanceof http.ServerResponse
+    const isHttp = response instanceof http.ServerResponse
     const path = base ? route.fullPath.replace(base, "") : route.fullPath
     const options: proxy.ServerOptions = {
       changeOrigin: true,
       ignorePath: true,
-      target: `${hxxp ? "http" : "ws"}://127.0.0.1:${port}${path}${
+      target: `${isHttp ? "http" : "ws"}://127.0.0.1:${port}${path}${
         Object.keys(route.query).length > 0 ? `?${querystring.stringify(route.query)}` : ""
       }`,
-      ws: !hxxp,
+      ws: !isHttp,
     }
 
     if (response instanceof http.ServerResponse) {

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -17,7 +17,7 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
   /**
    * Proxy domains are stored here without the leading `*.`
    */
-  public readonly proxyDomains: string[]
+  public readonly proxyDomains: Set<string>
   private readonly proxy = proxy.createProxyServer({})
 
   /**
@@ -26,7 +26,7 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
    */
   public constructor(options: HttpProviderOptions, proxyDomains: string[] = []) {
     super(options)
-    this.proxyDomains = proxyDomains.map((d) => d.replace(/^\*\./, "")).filter((d, i, arr) => arr.indexOf(d) === i)
+    this.proxyDomains = new Set(proxyDomains.map((d) => d.replace(/^\*\./, "")))
     this.proxy.on("error", (error) => logger.warn(error.message))
     // Intercept the response to rewrite absolute redirects against the base path.
     this.proxy.on("proxyRes", (response, request: Request) => {
@@ -124,7 +124,7 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
     // There must be an exact match.
     const port = parts.shift()
     const proxyDomain = parts.join(".")
-    if (!port || !this.proxyDomains.includes(proxyDomain)) {
+    if (!port || !this.proxyDomains.has(proxyDomain)) {
       return undefined
     }
 

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -1,3 +1,4 @@
+import { logger } from "@coder/logger"
 import * as http from "http"
 import proxy from "http-proxy"
 import * as net from "net"
@@ -21,6 +22,7 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
   public constructor(options: HttpProviderOptions, proxyDomains: string[] = []) {
     super(options)
     this.proxyDomains = proxyDomains.map((d) => d.replace(/^\*\./, "")).filter((d, i, arr) => arr.indexOf(d) === i)
+    this.proxy.on("error", (error) => logger.warn(error.message))
   }
 
   public async handleRequest(

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -1,0 +1,83 @@
+import * as http from "http"
+import { HttpCode, HttpError } from "../../common/http"
+import { AuthType, HttpProvider, HttpProviderOptions, HttpResponse, Route } from "../http"
+
+/**
+ * Proxy HTTP provider.
+ */
+export class ProxyHttpProvider extends HttpProvider {
+  public constructor(options: HttpProviderOptions, private readonly proxyDomains: string[]) {
+    super(options)
+  }
+
+  public async handleRequest(route: Route): Promise<HttpResponse> {
+    if (this.options.auth !== AuthType.Password || route.requestPath !== "/index.html") {
+      throw new HttpError("Not found", HttpCode.NotFound)
+    }
+    const payload = this.proxy(route.base.replace(/^\//, ""))
+    if (!payload) {
+      throw new HttpError("Not found", HttpCode.NotFound)
+    }
+    return payload
+  }
+
+  public async getRoot(route: Route, error?: Error): Promise<HttpResponse> {
+    const response = await this.getUtf8Resource(this.rootPath, "src/browser/pages/login.html")
+    response.content = response.content.replace(/{{ERROR}}/, error ? `<div class="error">${error.message}</div>` : "")
+    return this.replaceTemplates(route, response)
+  }
+
+  /**
+   * Return a response if the request should be proxied. Anything that ends in a
+   * proxy domain and has a subdomain should be proxied. The port is found in
+   * the top-most subdomain.
+   *
+   * For example, if the proxy domain is `coder.com` then `8080.coder.com` and
+   * `test.8080.coder.com` will both proxy to `8080` but `8080.test.coder.com`
+   * will have an error because `test` isn't a port. If the proxy domain was
+   * `test.coder.com` then it would work.
+   */
+  public maybeProxy(request: http.IncomingMessage): HttpResponse | undefined {
+    const host = request.headers.host
+    if (!host || !this.proxyDomains) {
+      return undefined
+    }
+
+    const proxyDomain = this.proxyDomains.find((d) => host.endsWith(d))
+    if (!proxyDomain) {
+      return undefined
+    }
+
+    const proxyDomainLength = proxyDomain.split(".").length
+    const portStr = host
+      .split(".")
+      .slice(0, -proxyDomainLength)
+      .pop()
+
+    if (!portStr) {
+      return undefined
+    }
+
+    return this.proxy(portStr)
+  }
+
+  private proxy(portStr: string): HttpResponse {
+    if (!portStr) {
+      return {
+        code: HttpCode.BadRequest,
+        content: "Port must be provided",
+      }
+    }
+    const port = parseInt(portStr, 10)
+    if (isNaN(port)) {
+      return {
+        code: HttpCode.BadRequest,
+        content: `"${portStr}" is not a valid number`,
+      }
+    }
+    return {
+      code: HttpCode.Ok,
+      content: `will proxy this to ${port}`,
+    }
+  }
+}

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -1,46 +1,12 @@
-import { logger } from "@coder/logger"
 import * as http from "http"
-import proxy from "http-proxy"
-import * as net from "net"
-import * as querystring from "querystring"
 import { HttpCode, HttpError } from "../../common/http"
-import { HttpProvider, HttpProviderOptions, HttpProxyProvider, HttpResponse, Route } from "../http"
-
-interface Request extends http.IncomingMessage {
-  base?: string
-}
+import { HttpProvider, HttpResponse, Route, WsResponse } from "../http"
 
 /**
  * Proxy HTTP provider.
  */
-export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider {
-  /**
-   * Proxy domains are stored here without the leading `*.`
-   */
-  public readonly proxyDomains: Set<string>
-  private readonly proxy = proxy.createProxyServer({})
-
-  /**
-   * Domains can be provided in the form `coder.com` or `*.coder.com`. Either
-   * way, `<number>.coder.com` will be proxied to `number`.
-   */
-  public constructor(options: HttpProviderOptions, proxyDomains: string[] = []) {
-    super(options)
-    this.proxyDomains = new Set(proxyDomains.map((d) => d.replace(/^\*\./, "")))
-    this.proxy.on("error", (error) => logger.warn(error.message))
-    // Intercept the response to rewrite absolute redirects against the base path.
-    this.proxy.on("proxyRes", (response, request: Request) => {
-      if (response.headers.location && response.headers.location.startsWith("/") && request.base) {
-        response.headers.location = request.base + response.headers.location
-      }
-    })
-  }
-
-  public async handleRequest(
-    route: Route,
-    request: http.IncomingMessage,
-    response: http.ServerResponse,
-  ): Promise<HttpResponse> {
+export class ProxyHttpProvider extends HttpProvider {
+  public async handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse> {
     if (!this.authenticated(request)) {
       if (this.isRoot(route)) {
         return { redirect: "/login", query: { to: route.fullPath } }
@@ -56,133 +22,22 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
     }
 
     const port = route.base.replace(/^\//, "")
-    const base = `${this.options.base}/${port}`
-    const payload = this.doProxy(route, request, response, port, base)
-    if (payload) {
-      return payload
+    return {
+      proxy: {
+        base: `${this.options.base}/${port}`,
+        port,
+      },
     }
-
-    throw new HttpError("Not found", HttpCode.NotFound)
   }
 
-  public async handleWebSocket(
-    route: Route,
-    request: http.IncomingMessage,
-    socket: net.Socket,
-    head: Buffer,
-  ): Promise<void> {
+  public async handleWebSocket(route: Route, request: http.IncomingMessage): Promise<WsResponse> {
     this.ensureAuthenticated(request)
     const port = route.base.replace(/^\//, "")
-    const base = `${this.options.base}/${port}`
-    this.doProxy(route, request, { socket, head }, port, base)
-  }
-
-  public getCookieDomain(host: string): string {
-    let current: string | undefined
-    this.proxyDomains.forEach((domain) => {
-      if (host.endsWith(domain) && (!current || domain.length < current.length)) {
-        current = domain
-      }
-    })
-    // Setting the domain to localhost doesn't seem to work for subdomains (for
-    // example dev.localhost).
-    return current && current !== "localhost" ? current : host
-  }
-
-  public maybeProxyRequest(
-    route: Route,
-    request: http.IncomingMessage,
-    response: http.ServerResponse,
-  ): HttpResponse | undefined {
-    const port = this.getPort(request)
-    return port ? this.doProxy(route, request, response, port) : undefined
-  }
-
-  public maybeProxyWebSocket(
-    route: Route,
-    request: http.IncomingMessage,
-    socket: net.Socket,
-    head: Buffer,
-  ): HttpResponse | undefined {
-    const port = this.getPort(request)
-    return port ? this.doProxy(route, request, { socket, head }, port) : undefined
-  }
-
-  private getPort(request: http.IncomingMessage): string | undefined {
-    // No proxy until we're authenticated. This will cause the login page to
-    // show as well as let our assets keep loading normally.
-    if (!this.authenticated(request)) {
-      return undefined
+    return {
+      proxy: {
+        base: `${this.options.base}/${port}`,
+        port,
+      },
     }
-
-    // Split into parts.
-    const host = request.headers.host || ""
-    const idx = host.indexOf(":")
-    const domain = idx !== -1 ? host.substring(0, idx) : host
-    const parts = domain.split(".")
-
-    // There must be an exact match.
-    const port = parts.shift()
-    const proxyDomain = parts.join(".")
-    if (!port || !this.proxyDomains.has(proxyDomain)) {
-      return undefined
-    }
-
-    return port
-  }
-
-  private doProxy(
-    route: Route,
-    request: http.IncomingMessage,
-    response: http.ServerResponse,
-    portStr: string,
-    base?: string,
-  ): HttpResponse
-  private doProxy(
-    route: Route,
-    request: http.IncomingMessage,
-    response: { socket: net.Socket; head: Buffer },
-    portStr: string,
-    base?: string,
-  ): HttpResponse
-  private doProxy(
-    route: Route,
-    request: http.IncomingMessage,
-    response: http.ServerResponse | { socket: net.Socket; head: Buffer },
-    portStr: string,
-    base?: string,
-  ): HttpResponse {
-    const port = parseInt(portStr, 10)
-    if (isNaN(port)) {
-      return {
-        code: HttpCode.BadRequest,
-        content: `"${portStr}" is not a valid number`,
-      }
-    }
-
-    // REVIEW: Absolute redirects need to be based on the subpath but I'm not
-    // sure how best to get this information to the `proxyRes` event handler.
-    // For now I'm sticking it on the request object which is passed through to
-    // the event.
-    ;(request as Request).base = base
-
-    const isHttp = response instanceof http.ServerResponse
-    const path = base ? route.fullPath.replace(base, "") : route.fullPath
-    const options: proxy.ServerOptions = {
-      changeOrigin: true,
-      ignorePath: true,
-      target: `${isHttp ? "http" : "ws"}://127.0.0.1:${port}${path}${
-        Object.keys(route.query).length > 0 ? `?${querystring.stringify(route.query)}` : ""
-      }`,
-      ws: !isHttp,
-    }
-
-    if (response instanceof http.ServerResponse) {
-      this.proxy.web(request, response, options)
-    } else {
-      this.proxy.ws(request, response.socket, response.head, options)
-    }
-
-    return { handled: true }
   }
 }

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -1,4 +1,6 @@
 import * as http from "http"
+import proxy from "http-proxy"
+import * as net from "net"
 import { HttpCode, HttpError } from "../../common/http"
 import { HttpProvider, HttpProviderOptions, HttpProxyProvider, HttpResponse, Route } from "../http"
 
@@ -10,6 +12,7 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
    * Proxy domains are stored here without the leading `*.`
    */
   public readonly proxyDomains: string[]
+  private readonly proxy = proxy.createProxyServer({})
 
   /**
    * Domains can be provided in the form `coder.com` or `*.coder.com`. Either
@@ -20,20 +23,35 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
     this.proxyDomains = proxyDomains.map((d) => d.replace(/^\*\./, "")).filter((d, i, arr) => arr.indexOf(d) === i)
   }
 
-  public async handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse> {
+  public async handleRequest(
+    route: Route,
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ): Promise<HttpResponse> {
     if (!this.authenticated(request)) {
-      if (route.requestPath === "/index.html") {
-        return { redirect: "/login", query: { to: route.fullPath } }
+      // Only redirect from the root. Other requests get an unauthorized error.
+      if (route.requestPath && route.requestPath !== "/index.html") {
+        throw new HttpError("Unauthorized", HttpCode.Unauthorized)
       }
-      throw new HttpError("Unauthorized", HttpCode.Unauthorized)
+      return { redirect: "/login", query: { to: route.fullPath } }
     }
 
-    const payload = this.proxy(route.base.replace(/^\//, ""))
+    const payload = this.doProxy(route.requestPath, request, response, route.base.replace(/^\//, ""))
     if (payload) {
       return payload
     }
 
     throw new HttpError("Not found", HttpCode.NotFound)
+  }
+
+  public async handleWebSocket(
+    route: Route,
+    request: http.IncomingMessage,
+    socket: net.Socket,
+    head: Buffer,
+  ): Promise<void> {
+    this.ensureAuthenticated(request)
+    this.doProxy(route.requestPath, request, socket, head, route.base.replace(/^\//, ""))
   }
 
   public getCookieDomain(host: string): string {
@@ -46,7 +64,26 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
     return current || host
   }
 
-  public maybeProxy(request: http.IncomingMessage): HttpResponse | undefined {
+  public maybeProxyRequest(
+    route: Route,
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ): HttpResponse | undefined {
+    const port = this.getPort(request)
+    return port ? this.doProxy(route.fullPath, request, response, port) : undefined
+  }
+
+  public maybeProxyWebSocket(
+    route: Route,
+    request: http.IncomingMessage,
+    socket: net.Socket,
+    head: Buffer,
+  ): HttpResponse | undefined {
+    const port = this.getPort(request)
+    return port ? this.doProxy(route.fullPath, request, socket, head, port) : undefined
+  }
+
+  private getPort(request: http.IncomingMessage): string | undefined {
     // No proxy until we're authenticated. This will cause the login page to
     // show as well as let our assets keep loading normally.
     if (!this.authenticated(request)) {
@@ -67,26 +104,58 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
       return undefined
     }
 
-    return this.proxy(port)
+    return port
   }
 
-  private proxy(portStr: string): HttpResponse {
-    if (!portStr) {
+  private doProxy(
+    path: string,
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+    portStr: string,
+  ): HttpResponse
+  private doProxy(
+    path: string,
+    request: http.IncomingMessage,
+    socket: net.Socket,
+    head: Buffer,
+    portStr: string,
+  ): HttpResponse
+  private doProxy(
+    path: string,
+    request: http.IncomingMessage,
+    responseOrSocket: http.ServerResponse | net.Socket,
+    headOrPortStr: Buffer | string,
+    portStr?: string,
+  ): HttpResponse {
+    const _portStr = typeof headOrPortStr === "string" ? headOrPortStr : portStr
+    if (!_portStr) {
       return {
         code: HttpCode.BadRequest,
         content: "Port must be provided",
       }
     }
-    const port = parseInt(portStr, 10)
+
+    const port = parseInt(_portStr, 10)
     if (isNaN(port)) {
       return {
         code: HttpCode.BadRequest,
-        content: `"${portStr}" is not a valid number`,
+        content: `"${_portStr}" is not a valid number`,
       }
     }
-    return {
-      code: HttpCode.Ok,
-      content: `will proxy this to ${port}`,
+
+    const options: proxy.ServerOptions = {
+      autoRewrite: true,
+      changeOrigin: true,
+      ignorePath: true,
+      target: `http://127.0.0.1:${port}${path}`,
     }
+
+    if (responseOrSocket instanceof net.Socket) {
+      this.proxy.ws(request, responseOrSocket, headOrPortStr, options)
+    } else {
+      this.proxy.web(request, responseOrSocket, options)
+    }
+
+    return { handled: true }
   }
 }

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -61,7 +61,9 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
         current = domain
       }
     })
-    return current || host
+    // Setting the domain to localhost doesn't seem to work for subdomains (for
+    // example dev.localhost).
+    return current && current !== "localhost" ? current : host
   }
 
   public maybeProxyRequest(
@@ -90,12 +92,11 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
       return undefined
     }
 
-    // At minimum there needs to be sub.domain.tld.
-    const host = request.headers.host
-    const parts = host && host.split(".")
-    if (!parts || parts.length < 3) {
-      return undefined
-    }
+    // Split into parts.
+    const host = request.headers.host || ""
+    const idx = host.indexOf(":")
+    const domain = idx !== -1 ? host.substring(0, idx) : host
+    const parts = domain.split(".")
 
     // There must be an exact match.
     const port = parts.shift()

--- a/src/node/app/proxy.ts
+++ b/src/node/app/proxy.ts
@@ -41,10 +41,8 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
     request: http.IncomingMessage,
     response: http.ServerResponse,
   ): Promise<HttpResponse> {
-    const isRoot = !route.requestPath || route.requestPath === "/index.html"
     if (!this.authenticated(request)) {
-      // Only redirect from the root. Other requests get an unauthorized error.
-      if (isRoot) {
+      if (this.isRoot(route)) {
         return { redirect: "/login", query: { to: route.fullPath } }
       }
       throw new HttpError("Unauthorized", HttpCode.Unauthorized)
@@ -53,7 +51,7 @@ export class ProxyHttpProvider extends HttpProvider implements HttpProxyProvider
     // Ensure there is a trailing slash so relative paths work correctly.
     const port = route.base.replace(/^\//, "")
     const base = `${this.options.base}/${port}`
-    if (isRoot && !route.fullPath.endsWith("/")) {
+    if (this.isRoot(route) && !route.fullPath.endsWith("/")) {
       return {
         redirect: `${base}/`,
       }

--- a/src/node/app/update.ts
+++ b/src/node/app/update.ts
@@ -61,7 +61,8 @@ export class UpdateHttpProvider extends HttpProvider {
     this.ensureAuthenticated(request)
     this.ensureMethod(request)
 
-    if (route.requestPath !== "/index.html") {
+    // Only serve root pages.
+    if (route.requestPath && route.requestPath !== "/index.html") {
       throw new HttpError("Not found", HttpCode.NotFound)
     }
 

--- a/src/node/app/update.ts
+++ b/src/node/app/update.ts
@@ -61,8 +61,7 @@ export class UpdateHttpProvider extends HttpProvider {
     this.ensureAuthenticated(request)
     this.ensureMethod(request)
 
-    // Only serve root pages.
-    if (route.requestPath && route.requestPath !== "/index.html") {
+    if (!this.isRoot(route)) {
       throw new HttpError("Not found", HttpCode.NotFound)
     }
 

--- a/src/node/app/vscode.ts
+++ b/src/node/app/vscode.ts
@@ -128,8 +128,7 @@ export class VscodeHttpProvider extends HttpProvider {
 
     switch (route.base) {
       case "/":
-        // Only serve this at the root.
-        if (route.requestPath && route.requestPath !== "/index.html") {
+        if (!this.isRoot(route)) {
           throw new HttpError("Not found", HttpCode.NotFound)
         } else if (!this.authenticated(request)) {
           return { redirect: "/login", query: { to: this.options.base } }

--- a/src/node/app/vscode.ts
+++ b/src/node/app/vscode.ts
@@ -128,7 +128,8 @@ export class VscodeHttpProvider extends HttpProvider {
 
     switch (route.base) {
       case "/":
-        if (route.requestPath !== "/index.html") {
+        // Only serve this at the root.
+        if (route.requestPath && route.requestPath !== "/index.html") {
           throw new HttpError("Not found", HttpCode.NotFound)
         } else if (!this.authenticated(request)) {
           return { redirect: "/login", query: { to: this.options.base } }

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -39,6 +39,7 @@ export interface Args extends VsArgs {
   readonly "install-extension"?: string[]
   readonly "show-versions"?: boolean
   readonly "uninstall-extension"?: string[]
+  readonly "proxy-domain"?: string[]
   readonly locale?: string
   readonly _: string[]
 }
@@ -111,6 +112,7 @@ const options: Options<Required<Args>> = {
   "install-extension": { type: "string[]", description: "Install or update a VS Code extension by id or vsix." },
   "uninstall-extension": { type: "string[]", description: "Uninstall a VS Code extension by id." },
   "show-versions": { type: "boolean", description: "Show VS Code extension versions." },
+  "proxy-domain": { type: "string[]", description: "Domain used for proxying ports." },
 
   locale: { type: "string" },
   log: { type: LogLevel },

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -56,19 +56,11 @@ const main = async (args: Args): Promise<void> => {
     throw new Error("--cert-key is missing")
   }
 
-  /**
-   * Domains can be in the form `coder.com` or `*.coder.com`. Either way,
-   * `[number].coder.com` will be proxied to `number`.
-   */
-  const proxyDomains = args["proxy-domain"]
-    ? args["proxy-domain"].map((d) => d.replace(/^\*\./, "")).filter((d, i, arr) => arr.indexOf(d) === i)
-    : []
-
   const httpServer = new HttpServer(options)
   const vscode = httpServer.registerHttpProvider("/", VscodeHttpProvider, args)
   const api = httpServer.registerHttpProvider("/api", ApiHttpProvider, httpServer, vscode, args["user-data-dir"])
   const update = httpServer.registerHttpProvider("/update", UpdateHttpProvider, !args["disable-updates"])
-  const proxy = httpServer.registerHttpProvider("/proxy", ProxyHttpProvider, proxyDomains)
+  const proxy = httpServer.registerHttpProvider("/proxy", ProxyHttpProvider, args["proxy-domain"])
   httpServer.registerHttpProvider("/login", LoginHttpProvider)
   httpServer.registerHttpProvider("/static", StaticHttpProvider)
   httpServer.registerHttpProvider("/dashboard", DashboardHttpProvider, api, update)
@@ -102,11 +94,11 @@ const main = async (args: Args): Promise<void> => {
     logger.info("  - Not serving HTTPS")
   }
 
-  if (proxyDomains.length === 1) {
-    logger.info(`  - Proxying *.${proxyDomains[0]}`)
-  } else if (proxyDomains && proxyDomains.length > 1) {
+  if (proxy.proxyDomains.length === 1) {
+    logger.info(`  - Proxying *.${proxy.proxyDomains[0]}`)
+  } else if (proxy.proxyDomains.length > 1) {
     logger.info("  - Proxying the following domains:")
-    proxyDomains.forEach((domain) => logger.info(`    - *.${domain}`))
+    proxy.proxyDomains.forEach((domain) => logger.info(`    - *.${domain}`))
   }
 
   logger.info(`Automatic updates are ${update.enabled ? "enabled" : "disabled"}`)

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -94,10 +94,8 @@ const main = async (args: Args): Promise<void> => {
     logger.info("  - Not serving HTTPS")
   }
 
-  if (proxy.proxyDomains.length === 1) {
-    logger.info(`  - Proxying *.${proxy.proxyDomains[0]}`)
-  } else if (proxy.proxyDomains.length > 1) {
-    logger.info("  - Proxying the following domains:")
+  if (proxy.proxyDomains.size > 0) {
+    logger.info(`  - Proxying the following domain${proxy.proxyDomains.size === 1 ? "" : "s"}:`)
     proxy.proxyDomains.forEach((domain) => logger.info(`    - *.${domain}`))
   }
 

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -359,6 +359,14 @@ export abstract class HttpProvider {
     }
     return cookies as T
   }
+
+  /**
+   * Return true if the route is for the root page. For example /base, /base/,
+   * or /base/index.html but not /base/path or /base/file.js.
+   */
+  protected isRoot(route: Route): boolean {
+    return !route.requestPath || route.requestPath === "/index.html"
+  }
 }
 
 /**

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -596,7 +596,7 @@ export class HttpServer {
                 `Path=${normalize(payload.cookie.path || "/", true)}`,
                 domain ? `Domain=${(this.proxy && this.proxy.getCookieDomain(domain)) || domain}` : undefined,
                 // "HttpOnly",
-                "SameSite=strict",
+                "SameSite=lax",
               ]
                 .filter((l) => !!l)
                 .join(";"),
@@ -633,9 +633,11 @@ export class HttpServer {
       if (error.code === "ENOENT" || error.code === "EISDIR") {
         e = new HttpError("Not found", HttpCode.NotFound)
       }
-      logger.debug("Request error", field("url", request.url))
-      logger.debug(error.stack)
       const code = typeof e.code === "number" ? e.code : HttpCode.ServerError
+      logger.debug("Request error", field("url", request.url), field("code", code))
+      if (code >= HttpCode.ServerError) {
+        logger.error(error.stack)
+      }
       const payload = await route.provider.getErrorRoot(route, code, code, e.message)
       write({
         code,

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -99,6 +99,7 @@ export interface HttpServerOptions {
   readonly commit?: string
   readonly host?: string
   readonly password?: string
+  readonly proxyDomains?: string[]
   readonly port?: number
   readonly socket?: string
 }

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -490,7 +490,10 @@ export class HttpServer {
     } else {
       this.server = http.createServer(this.onRequest)
     }
-    this.proxy.on("error", (error) => logger.warn(error.message))
+    this.proxy.on("error", (error, _request, response) => {
+      response.writeHead(HttpCode.ServerError)
+      response.end(error.message)
+    })
     // Intercept the response to rewrite absolute redirects against the base path.
     this.proxy.on("proxyRes", (response, request: ProxyRequest) => {
       if (response.headers.location && response.headers.location.startsWith("/") && request.base) {

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -526,9 +526,12 @@ export class HttpServer {
               "Set-Cookie": [
                 `${payload.cookie.key}=${payload.cookie.value}`,
                 `Path=${normalize(payload.cookie.path || "/", true)}`,
+                request.headers.host ? `Domain=${request.headers.host}` : undefined,
                 // "HttpOnly",
                 "SameSite=strict",
-              ].join(";"),
+              ]
+                .filter((l) => !!l)
+                .join(";"),
             }
           : {}),
         ...payload.headers,

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -1,6 +1,7 @@
 import { field, logger } from "@coder/logger"
 import * as fs from "fs-extra"
 import * as http from "http"
+import proxy from "http-proxy"
 import * as httpolyglot from "httpolyglot"
 import * as https from "https"
 import * as net from "net"
@@ -18,6 +19,10 @@ import { getMediaMime, xdgLocalDir } from "./util"
 export type Cookies = { [key: string]: string[] | undefined }
 export type PostData = { [key: string]: string | string[] | undefined }
 
+interface ProxyRequest extends http.IncomingMessage {
+  base?: string
+}
+
 interface AuthPayload extends Cookies {
   key?: string[]
 }
@@ -28,6 +33,17 @@ export enum AuthType {
 }
 
 export type Query = { [key: string]: string | string[] | undefined }
+
+export interface ProxyOptions {
+  /**
+   * A base path to strip from from the request before proxying if necessary.
+   */
+  base?: string
+  /**
+   * The port to proxy.
+   */
+  port: string
+}
 
 export interface HttpResponse<T = string | Buffer | object> {
   /*
@@ -78,9 +94,16 @@ export interface HttpResponse<T = string | Buffer | object> {
    */
   query?: Query
   /**
-   * Indicates the request was handled and nothing else needs to be done.
+   * Indicates the request should be proxied.
    */
-  handled?: boolean
+  proxy?: ProxyOptions
+}
+
+export interface WsResponse {
+  /**
+   * Indicates the web socket should be proxied.
+   */
+  proxy?: ProxyOptions
 }
 
 /**
@@ -104,6 +127,7 @@ export interface HttpServerOptions {
   readonly host?: string
   readonly password?: string
   readonly port?: number
+  readonly proxyDomains?: string[]
   readonly socket?: string
 }
 
@@ -156,7 +180,9 @@ export abstract class HttpProvider {
   }
 
   /**
-   * Handle web sockets on the registered endpoint.
+   * Handle web sockets on the registered endpoint. Normally the provider
+   * handles the request itself but it can return a response when necessary. The
+   * default is to throw a 404.
    */
   public handleWebSocket(
     /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -165,18 +191,14 @@ export abstract class HttpProvider {
     _socket: net.Socket,
     _head: Buffer,
     /* eslint-enable @typescript-eslint/no-unused-vars */
-  ): Promise<void> {
+  ): Promise<WsResponse | void> {
     throw new HttpError("Not found", HttpCode.NotFound)
   }
 
   /**
    * Handle requests to the registered endpoint.
    */
-  public abstract handleRequest(
-    route: Route,
-    request: http.IncomingMessage,
-    response: http.ServerResponse,
-  ): Promise<HttpResponse>
+  public abstract handleRequest(route: Route, request: http.IncomingMessage): Promise<HttpResponse>
 
   /**
    * Get the base relative to the provided route. For each slash we need to go
@@ -288,7 +310,7 @@ export abstract class HttpProvider {
    * Return the provided password value if the payload contains the right
    * password otherwise return false. If no payload is specified use cookies.
    */
-  protected authenticated(request: http.IncomingMessage, payload?: AuthPayload): string | boolean {
+  public authenticated(request: http.IncomingMessage, payload?: AuthPayload): string | boolean {
     switch (this.options.auth) {
       case AuthType.None:
         return true
@@ -426,39 +448,6 @@ export interface HttpProvider3<A1, A2, A3, T> {
   new (options: HttpProviderOptions, a1: A1, a2: A2, a3: A3): T
 }
 
-export interface HttpProxyProvider {
-  /**
-   * Return a response if the request should be proxied. Anything that ends in a
-   * proxy domain and has a *single* subdomain should be proxied. Anything else
-   * should return `undefined` and will be handled as normal.
-   *
-   * For example if `coder.com` is specified `8080.coder.com` will be proxied
-   * but `8080.test.coder.com` and `test.8080.coder.com` will not.
-   */
-  maybeProxyRequest(
-    route: Route,
-    request: http.IncomingMessage,
-    response: http.ServerResponse,
-  ): HttpResponse | undefined
-
-  /**
-   * Same concept as `maybeProxyRequest` but for web sockets.
-   */
-  maybeProxyWebSocket(
-    route: Route,
-    request: http.IncomingMessage,
-    socket: net.Socket,
-    head: Buffer,
-  ): HttpResponse | undefined
-
-  /**
-   * Get the domain that should be used for setting a cookie. This will allow
-   * the user to authenticate only once. This will return the highest level
-   * domain (e.g. `coder.com` over `test.coder.com` if both are specified).
-   */
-  getCookieDomain(host: string): string | undefined
-}
-
 /**
  * An HTTP server. Its main role is to route incoming HTTP requests to the
  * appropriate provider for that endpoint then write out the response. It also
@@ -471,9 +460,19 @@ export class HttpServer {
   private readonly providers = new Map<string, HttpProvider>()
   private readonly heart: Heart
   private readonly socketProvider = new SocketProxyProvider()
-  private proxy?: HttpProxyProvider
+
+  /**
+   * Proxy domains are stored here without the leading `*.`
+   */
+  public readonly proxyDomains: Set<string>
+
+  /**
+   * Provides the actual proxying functionality.
+   */
+  private readonly proxy = proxy.createProxyServer({})
 
   public constructor(private readonly options: HttpServerOptions) {
+    this.proxyDomains = new Set((options.proxyDomains || []).map((d) => d.replace(/^\*\./, "")))
     this.heart = new Heart(path.join(xdgLocalDir, "heartbeat"), async () => {
       const connections = await this.getConnections()
       logger.trace(`${connections} active connection${plural(connections)}`)
@@ -491,6 +490,13 @@ export class HttpServer {
     } else {
       this.server = http.createServer(this.onRequest)
     }
+    this.proxy.on("error", (error) => logger.warn(error.message))
+    // Intercept the response to rewrite absolute redirects against the base path.
+    this.proxy.on("proxyRes", (response, request: ProxyRequest) => {
+      if (response.headers.location && response.headers.location.startsWith("/") && request.base) {
+        response.headers.location = request.base + response.headers.location
+      }
+    })
   }
 
   public dispose(): void {
@@ -547,14 +553,6 @@ export class HttpServer {
   }
 
   /**
-   * Register a provider as a proxy. It will be consulted before any other
-   * provider.
-   */
-  public registerProxy(proxy: HttpProxyProvider): void {
-    this.proxy = proxy
-  }
-
-  /**
    * Start listening on the specified port.
    */
   public listen(): Promise<string | null> {
@@ -602,7 +600,7 @@ export class HttpServer {
               "Set-Cookie": [
                 `${payload.cookie.key}=${payload.cookie.value}`,
                 `Path=${normalize(payload.cookie.path || "/", true)}`,
-                domain ? `Domain=${(this.proxy && this.proxy.getCookieDomain(domain)) || domain}` : undefined,
+                domain ? `Domain=${this.getCookieDomain(domain)}` : undefined,
                 // "HttpOnly",
                 "SameSite=lax",
               ]
@@ -631,9 +629,11 @@ export class HttpServer {
     try {
       const payload =
         this.maybeRedirect(request, route) ||
-        (this.proxy && this.proxy.maybeProxyRequest(route, request, response)) ||
-        (await route.provider.handleRequest(route, request, response))
-      if (!payload.handled) {
+        (route.provider.authenticated(request) && this.maybeProxy(request)) ||
+        (await route.provider.handleRequest(route, request))
+      if (payload.proxy) {
+        this.doProxy(route, request, response, payload.proxy)
+      } else {
         write(payload)
       }
     } catch (error) {
@@ -710,8 +710,13 @@ export class HttpServer {
         throw new HttpError("Not found", HttpCode.NotFound)
       }
 
-      if (!this.proxy || !this.proxy.maybeProxyWebSocket(route, request, socket, head)) {
-        await route.provider.handleWebSocket(route, request, await this.socketProvider.createProxy(socket), head)
+      // The socket proxy is so we can pass them to child processes (TLS sockets
+      // can't be transferred so we need an in-between).
+      const socketProxy = await this.socketProvider.createProxy(socket)
+      const payload =
+        this.maybeProxy(request) || (await route.provider.handleWebSocket(route, request, socketProxy, head))
+      if (payload && payload.proxy) {
+        this.doProxy(route, request, { socket: socketProxy, head }, payload.proxy)
       }
     } catch (error) {
       socket.destroy(error)
@@ -755,5 +760,107 @@ export class HttpServer {
       throw new Error(`No provider for ${base}`)
     }
     return { base, fullPath, requestPath, query: parsedUrl.query, provider, originalPath }
+  }
+
+  /**
+   * Proxy a request to the target.
+   */
+  private doProxy(
+    route: Route,
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+    options: ProxyOptions,
+  ): void
+  /**
+   * Proxy a web socket to the target.
+   */
+  private doProxy(
+    route: Route,
+    request: http.IncomingMessage,
+    response: { socket: net.Socket; head: Buffer },
+    options: ProxyOptions,
+  ): void
+  /**
+   * Proxy a request or web socket to the target.
+   */
+  private doProxy(
+    route: Route,
+    request: http.IncomingMessage,
+    response: http.ServerResponse | { socket: net.Socket; head: Buffer },
+    options: ProxyOptions,
+  ): void {
+    const port = parseInt(options.port, 10)
+    if (isNaN(port)) {
+      throw new HttpError(`"${options.port}" is not a valid number`, HttpCode.BadRequest)
+    }
+
+    // REVIEW: Absolute redirects need to be based on the subpath but I'm not
+    // sure how best to get this information to the `proxyRes` event handler.
+    // For now I'm sticking it on the request object which is passed through to
+    // the event.
+    ;(request as ProxyRequest).base = options.base
+
+    const isHttp = response instanceof http.ServerResponse
+    const path = options.base ? route.fullPath.replace(options.base, "") : route.fullPath
+    const proxyOptions: proxy.ServerOptions = {
+      changeOrigin: true,
+      ignorePath: true,
+      target: `${isHttp ? "http" : "ws"}://127.0.0.1:${port}${path}${
+        Object.keys(route.query).length > 0 ? `?${querystring.stringify(route.query)}` : ""
+      }`,
+      ws: !isHttp,
+    }
+
+    if (response instanceof http.ServerResponse) {
+      this.proxy.web(request, response, proxyOptions)
+    } else {
+      this.proxy.ws(request, response.socket, response.head, proxyOptions)
+    }
+  }
+
+  /**
+   * Get the domain that should be used for setting a cookie. This will allow
+   * the user to authenticate only once. This will return the highest level
+   * domain (e.g. `coder.com` over `test.coder.com` if both are specified).
+   */
+  private getCookieDomain(host: string): string {
+    let current: string | undefined
+    this.proxyDomains.forEach((domain) => {
+      if (host.endsWith(domain) && (!current || domain.length < current.length)) {
+        current = domain
+      }
+    })
+    // Setting the domain to localhost doesn't seem to work for subdomains (for
+    // example dev.localhost).
+    return current && current !== "localhost" ? current : host
+  }
+
+  /**
+   * Return a response if the request should be proxied. Anything that ends in a
+   * proxy domain and has a *single* subdomain should be proxied. Anything else
+   * should return `undefined` and will be handled as normal.
+   *
+   * For example if `coder.com` is specified `8080.coder.com` will be proxied
+   * but `8080.test.coder.com` and `test.8080.coder.com` will not.
+   */
+  public maybeProxy(request: http.IncomingMessage): HttpResponse | undefined {
+    // Split into parts.
+    const host = request.headers.host || ""
+    const idx = host.indexOf(":")
+    const domain = idx !== -1 ? host.substring(0, idx) : host
+    const parts = domain.split(".")
+
+    // There must be an exact match.
+    const port = parts.shift()
+    const proxyDomain = parts.join(".")
+    if (!port || !this.proxyDomains.has(proxyDomain)) {
+      return undefined
+    }
+
+    return {
+      proxy: {
+        port,
+      },
+    }
   }
 }

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -581,6 +581,9 @@ export class HttpServer {
     this.heart.beat()
     const route = this.parseUrl(request)
     const write = (payload: HttpResponse): void => {
+      const host = request.headers.host || ""
+      const idx = host.indexOf(":")
+      const domain = idx !== -1 ? host.substring(0, idx) : host
       response.writeHead(payload.redirect ? HttpCode.Redirect : payload.code || HttpCode.Ok, {
         "Content-Type": payload.mime || getMediaMime(payload.filePath),
         ...(payload.redirect ? { Location: this.constructRedirect(request, route, payload as RedirectResponse) } : {}),
@@ -591,9 +594,7 @@ export class HttpServer {
               "Set-Cookie": [
                 `${payload.cookie.key}=${payload.cookie.value}`,
                 `Path=${normalize(payload.cookie.path || "/", true)}`,
-                request.headers.host
-                  ? `Domain=${(this.proxy && this.proxy.getCookieDomain(request.headers.host)) || request.headers.host}`
-                  : undefined,
+                domain ? `Domain=${(this.proxy && this.proxy.getCookieDomain(domain)) || domain}` : undefined,
                 // "HttpOnly",
                 "SameSite=strict",
               ]

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -117,6 +117,7 @@ describe("cli", () => {
     assert.throws(() => parse(["--auth=", "--log=debug"]), /--auth requires a value/)
     assert.throws(() => parse(["--auth", "--log"]), /--auth requires a value/)
     assert.throws(() => parse(["--auth", "--invalid"]), /--auth requires a value/)
+    assert.throws(() => parse(["--ssh-host-key"]), /--ssh-host-key requires a value/)
   })
 
   it("should error if value is invalid", () => {
@@ -158,6 +159,21 @@ describe("cli", () => {
       "extensions-dir": path.join(xdgLocalDir, "extensions"),
       "user-data-dir": xdgLocalDir,
       auth: "none",
+    })
+  })
+
+  it("should support repeatable flags", () => {
+    assert.deepEqual(parse(["--proxy-domain", "*.coder.com"]), {
+      _: [],
+      "extensions-dir": path.join(xdgLocalDir, "extensions"),
+      "user-data-dir": xdgLocalDir,
+      "proxy-domain": ["*.coder.com"],
+    })
+    assert.deepEqual(parse(["--proxy-domain", "*.coder.com", "--proxy-domain", "test.com"]), {
+      _: [],
+      "extensions-dir": path.join(xdgLocalDir, "extensions"),
+      "user-data-dir": xdgLocalDir,
+      "proxy-domain": ["*.coder.com", "test.com"],
     })
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -871,6 +871,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/http-proxy@^1.17.4":
+  version "1.17.4"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.4.tgz#e7c92e3dbe3e13aa799440ff42e6d3a17a9d045b"
+  integrity sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -2240,7 +2247,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.2.6:
+debug@3.2.6, debug@^3.0.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2745,6 +2752,11 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
+eventemitter3@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.0.tgz#d65176163887ee59f386d64c82610b696a4a74eb"
+  integrity sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==
+
 events@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.1.0.tgz#84279af1b34cb75aa88bf5ff291f6d0bd9b31a59"
@@ -2979,6 +2991,13 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+
+follow-redirects@^1.0.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.10.0.tgz#01f5263aee921c6a54fb91667f08f4155ce169eb"
+  integrity sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==
+  dependencies:
+    debug "^3.0.0"
 
 for-in@^1.0.2:
   version "1.0.2"
@@ -3402,6 +3421,15 @@ http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-proxy@^1.18.0:
+  version "1.18.0"
+  resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.0.tgz#dbe55f63e75a347db7f3d99974f2692a314a6a3a"
+  integrity sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==
+  dependencies:
+    eventemitter3 "^4.0.0"
+    follow-redirects "^1.0.0"
+    requires-port "^1.0.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -5893,6 +5921,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requires-port@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
+  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
 resolve-from@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR adds the ability to proxy HTTP ports through code-server.

To do this, you pass a domain on the command line. For example:

```
code-server --proxy-domain coder.com --proxy-domain test.coder.com
```

Domains can be in the format `coder.com` or `*.coder.com` and the flag can be repeated to add as many domains as you want.

When code-server encounters `[number].[domain]` in the host header it'll proxy to the port indicated by `[number]` if `[domain]` matches one of the provided proxy domains. For example, going to `8080.coder.com` in this example would proxy code-server to itself.

When authenticating the cookie will be set against the highest-level proxy. So in this example if you logged in at `8080.test.coder.com` the cookie would be set against `coder.com` since that's the highest level that matches in the provided list of domains. That way you only have to authenticate once.

**Edit**: `/proxy/[number]` will also work. No command-line flags are necessary to enable this.