### PR TITLE
Back up old directory when updating

### DIFF
--- a/ci/vscode.patch
+++ b/ci/vscode.patch
@@ -512,7 +512,7 @@ index eab8591492..26668701f7 100644
  					options.logService.error(`${logPrefix} socketFactory.connect() failed. Error:`);
 diff --git a/src/vs/server/browser/client.ts b/src/vs/server/browser/client.ts
 new file mode 100644
-index 0000000000..a27a6f3a45
+index 0000000000..4f8543d975
 --- /dev/null
 +++ b/src/vs/server/browser/client.ts
 @@ -0,0 +1,266 @@
@@ -692,7 +692,7 @@ index 0000000000..a27a6f3a45
 +			headers: { "content-type": "application/json" },
 +		});
 +		if (response.status !== 200) {
-+			throw new Error("Unexpected response");
++			throw new Error(response.statusText);
 +		}
 +
 +		const json = await response.json();

--- a/ci/vscode.patch
+++ b/ci/vscode.patch
@@ -512,10 +512,10 @@ index eab8591492..26668701f7 100644
  					options.logService.error(`${logPrefix} socketFactory.connect() failed. Error:`);
 diff --git a/src/vs/server/browser/client.ts b/src/vs/server/browser/client.ts
 new file mode 100644
-index 0000000000..96fbd4b0bb
+index 0000000000..a27a6f3a45
 --- /dev/null
 +++ b/src/vs/server/browser/client.ts
-@@ -0,0 +1,270 @@
+@@ -0,0 +1,266 @@
 +import { Emitter } from 'vs/base/common/event';
 +import { URI } from 'vs/base/common/uri';
 +import { localize } from 'vs/nls';
@@ -696,10 +696,6 @@ index 0000000000..96fbd4b0bb
 +		}
 +
 +		const json = await response.json();
-+		if (!json.isLatest) {
-+			throw new Error("Update failed");
-+		}
-+
 +		(services.get(INotificationService) as INotificationService).info(`Updated to ${json.version}`);
 +	};
 +

--- a/src/node/app/update.ts
+++ b/src/node/app/update.ts
@@ -221,8 +221,13 @@ export class UpdateHttpProvider extends HttpProvider {
         targetPath = path.resolve(__dirname, "../../../")
       }
 
-      logger.debug("Replacing files", field("target", targetPath))
-      await fs.move(directoryPath, targetPath, { overwrite: true })
+      // Move the old directory to prevent potential data loss.
+      const backupPath = path.resolve(targetPath, `../${path.basename(targetPath)}.${Date.now().toString()}`)
+      logger.debug("Replacing files", field("target", targetPath), field("backup", backupPath))
+      await fs.move(targetPath, backupPath)
+
+      // Move the new directory.
+      await fs.move(directoryPath, targetPath)
 
       await fs.remove(downloadPath)
 

--- a/test/update.test.ts
+++ b/test/update.test.ts
@@ -214,13 +214,18 @@ describe("update", () => {
     await p.downloadAndApplyUpdate(update, destination)
     assert.equal(`console.log("UPDATED")`, await fs.readFile(entry, "utf8"))
 
-    // Should still work if there is no existing version somehow.
-    await fs.remove(destination)
-    await p.downloadAndApplyUpdate(update, destination)
-    assert.equal(`console.log("UPDATED")`, await fs.readFile(entry, "utf8"))
+    // There should be a backup.
+    const dir = (await fs.readdir(path.join(tmpdir, "tests/updates"))).filter((dir) => {
+      return dir.startsWith("code-server.")
+    })
+    assert.equal(dir.length, 1)
+    assert.equal(
+      `console.log("OLD")`,
+      await fs.readFile(path.join(tmpdir, "tests/updates", dir[0], "code-server"), "utf8"),
+    )
 
     const archiveName = await p.getReleaseName(update)
-    assert.deepEqual(spy, ["/latest", `/download/${version}/${archiveName}`, `/download/${version}/${archiveName}`])
+    assert.deepEqual(spy, ["/latest", `/download/${version}/${archiveName}`])
   })
 
   it("should not reject if unable to fetch", async () => {


### PR DESCRIPTION
Rename the old directory with a timestamp before moving the new directory into place.

Also has a minor fix for a notification saying the update failed when it didn't (`isLatest`
won't be true since that version is still technically the older version).

Fixes #1483 .