### PR TITLE
fix macOS spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ Use [sshcode](https://github.com/codercom/sshcode) for a simple setup.
 
 ### Releases
 
-1. [Download a release](https://github.com/cdr/code-server/releases). (Linux and
-   OS X supported. Windows support planned.)
+1. [Download a release](https://github.com/cdr/code-server/releases). (Linux and macOS supported. Windows support planned.)
 2. Unpack the downloaded release then run the included `code-server` script.
 3. In your browser navigate to `localhost:8080`.
 


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.
-->

Apple calls the OS currently macOS.