### PR TITLE
Downgrade CI to Debian 8 for glibc 2.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
           name: npm-package
           path: ./release
       - name: Run ./ci/steps/release-static.sh
-        uses: ./ci/container
+        uses: ./ci/container/arm64
         with:
           args: ./ci/steps/release-static.sh
       - name: Upload release artifacts
@@ -138,7 +138,7 @@ jobs:
           name: release-packages
           path: ./release-packages
       - name: Run ./ci/steps/build-docker-image.sh
-        uses: ./ci/container
+        uses: ./ci/container/arm64
         with:
           args: ./ci/steps/build-docker-image.sh
       - name: Upload release image

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ systemctl --user enable --now code-server
 ### npm
 
 We recommend installing from `npm` if we don't have a precompiled release for your machine's
-platform or architecture.
+platform or architecture or your glibc < v2.19.
 
 **note:** Installing via `npm` builds native modules on install and so requires C dependencies.
 See [./doc/npm.md](./doc/npm.md) for installing these dependencies.

--- a/ci/README.md
+++ b/ci/README.md
@@ -23,11 +23,12 @@ Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) 
 5. Run `yarn release:github-assets` to download the `release-packages` artifact and then
    upload them to the draft release.
 6. Run some basic sanity tests on one of the released packages.
-7. Publish the release.
+7. Make sure the github release tag is the commit with the artifacts.
+8. Publish the release.
    1. CI will automatically grab the artifacts and then:
       1. Publish the NPM package from `npm-package`.
       2. Publish the Docker Hub image from `release-images`.
-8. Update the homebrew and AUR packages.
+9. Update the homebrew and AUR packages.
 
 ## dev
 

--- a/ci/container/arm64/Dockerfile
+++ b/ci/container/arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8
+FROM debian:9
 
 RUN apt-get update
 

--- a/ci/container/arm64/README.md
+++ b/ci/container/arm64/README.md
@@ -1,0 +1,6 @@
+# arm64
+
+Unfortunately there is no arm64 build of `debian:8` so
+we need to use `debian:9` instead.
+
+This is just an exact copy of [../Dockerfile](../Dockerfile) with the base image change.

--- a/ci/dev/lint.sh
+++ b/ci/dev/lint.sh
@@ -7,7 +7,10 @@ main() {
   eslint --max-warnings=0 --fix $(git ls-files "*.ts" "*.tsx" "*.js")
   stylelint $(git ls-files "*.css")
   tsc --noEmit
-  shellcheck -e SC2046,SC2164,SC2154 $(git ls-files "*.sh")
+  # See comment in ./ci/container/Dockerfile
+  if [[ ! ${CI-} ]]; then
+    shellcheck -e SC2046,SC2164,SC2154 $(git ls-files "*.sh")
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
Closes https://github.com/cdr/code-server/issues/1656


<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.
-->