### PR TITLE
Release v3.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ docker run -it -p 127.0.0.1:8080:8080 \
 ### Static Releases
 
 We publish self contained `.tar.gz` archives for every release on [github](https://github.com/cdr/code-server/releases).
-They bundle the node binary and compiled native modules.
+They bundle the node binary and node_modules.
 
 1. Download the latest release archive for your system from [github](https://github.com/cdr/code-server/releases).
 2. Unpack the release.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ For a full setup and walkthrough, please see [./doc/guide.md](./doc/guide.md).
 ### Debian, Ubuntu
 
 ```bash
-curl -sSOL https://github.com/cdr/code-server/releases/download/v3.3.0/code-server_3.3.0_amd64.deb
-sudo dpkg -i code-server_3.3.0_amd64.deb
+curl -sSOL https://github.com/cdr/code-server/releases/download/v3.3.1/code-server_3.3.1_amd64.deb
+sudo dpkg -i code-server_3.3.1_amd64.deb
 systemctl --user enable --now code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -27,8 +27,8 @@ systemctl --user enable --now code-server
 ### Fedora, Red Hat, SUSE
 
 ```bash
-curl -sSOL https://github.com/cdr/code-server/releases/download/v3.3.0/code-server-3.3.0-amd64.rpm
-sudo yum install -y code-server-3.3.0-amd64.rpm
+curl -sSOL https://github.com/cdr/code-server/releases/download/v3.3.1/code-server-3.3.1-amd64.rpm
+sudo yum install -y code-server-3.3.1-amd64.rpm
 systemctl --user enable --now code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -84,10 +84,10 @@ Add the code-server `bin` directory to your `$PATH` to easily execute `code-serv
 Here is an example script for installing and using a static `code-server` release on Linux:
 
 ```bash
-curl -sSL https://github.com/cdr/code-server/releases/download/v3.3.0/code-server-3.3.0-linux-amd64.tar.gz \
+curl -sSL https://github.com/cdr/code-server/releases/download/v3.3.1/code-server-3.3.1-linux-amd64.tar.gz \
   | sudo tar -C /usr/local -xz
-sudo mv /usr/local/code-server-3.3.0-linux-amd64 /usr/local/code-server-3.3.0
-PATH="/usr/local/code-server-3.3.0/bin:$PATH"
+sudo mv /usr/local/code-server-3.3.1-linux-amd64 /usr/local/code-server-3.3.1
+PATH="/usr/local/code-server-3.3.1/bin:$PATH"
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```

--- a/ci/README.md
+++ b/ci/README.md
@@ -14,7 +14,7 @@ Any file or directory in this subdirectory should be documented here.
 
 Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) installed.
 
-1. Update the version of code-server in `package.json` and README.md/guide.md install examples and push a commit.
+1. Update the version of code-server in `package.json` and README.md/guide.md install examples and make a PR.
 2. GitHub actions will generate the `npm-package`, `release-packages` and `release-images` artifacts.
 3. Run `yarn release:github-draft` to create a GitHub draft release from the template with
    the updated version.
@@ -24,7 +24,7 @@ Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) 
    upload them to the draft release.
 6. Run some basic sanity tests on one of the released packages.
 7. Make sure the github release tag is the commit with the artifacts.
-8. Publish the release.
+8. Publish the release and merge the PR.
    1. CI will automatically grab the artifacts and then:
       1. Publish the NPM package from `npm-package`.
       2. Publish the Docker Hub image from `release-images`.
@@ -70,7 +70,7 @@ You can disable minification by setting `MINIFY=`.
   - Bundles the output of the above two scripts into a single node module at `./release`.
 - [./ci/build/build-static-release.sh](./build/build-static-release.sh) (`yarn release:static`)
   - Requires a node module already built into `./release` with the above script.
-  - Will build a static release with node and native modules bundled into `./release-static`.
+  - Will build a static release with node and node_modules bundled into `./release-static`.
 - [./ci/build/clean.sh](./build/clean.sh) (`yarn clean`)
   - Removes all build artifacts.
   - Will also `git reset --hard lib/vscode`.

--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -49,11 +49,14 @@ EOF
 
 bundle_vscode() {
   mkdir -p "$VSCODE_OUT_PATH"
-  rsync "$VSCODE_SRC_PATH/package.json" "$VSCODE_OUT_PATH"
   rsync "$VSCODE_SRC_PATH/yarn.lock" "$VSCODE_OUT_PATH"
-  rsync "$VSCODE_SRC_PATH/node_modules" "$VSCODE_OUT_PATH"
   rsync "$VSCODE_SRC_PATH/out-vscode${MINIFY+-min}/" "$VSCODE_OUT_PATH/out"
+
   rsync "$VSCODE_SRC_PATH/.build/extensions/" "$VSCODE_OUT_PATH/extensions"
+  rm -Rf "$VSCODE_OUT_PATH/extensions/node_modules"
+  rsync "$VSCODE_SRC_PATH/extensions/package.json" "$VSCODE_OUT_PATH/extensions"
+  rsync "$VSCODE_SRC_PATH/extensions/yarn.lock" "$VSCODE_OUT_PATH/extensions"
+  rsync "$VSCODE_SRC_PATH/extensions/postinstall.js" "$VSCODE_OUT_PATH/extensions"
 
   mkdir -p "$VSCODE_OUT_PATH/resources/linux"
   rsync "$VSCODE_SRC_PATH/resources/linux/code.png" "$VSCODE_OUT_PATH/resources/linux/code.png"
@@ -68,26 +71,10 @@ bundle_vscode() {
 EOF
   ) > "$VSCODE_OUT_PATH/product.json"
 
-  pushd "$VSCODE_OUT_PATH"
-  yarn --production --frozen-lockfile --ignore-scripts
-  popd
-
-  # We clear any native module builds.
-  local native_modules
-  mapfile -t native_modules < <(find "$VSCODE_OUT_PATH/node_modules" -name "binding.gyp" -exec dirname {} \;)
-  local nm
-  for nm in "${native_modules[@]}"; do
-    rm -R "$nm/build"
-  done
-
-  # We have to rename node_modules to node_modules.bundled to avoid them being ignored by yarn.
-  local node_modules
-  mapfile -t node_modules < <(find "$VSCODE_OUT_PATH" -depth -name "node_modules")
-  local nm
-  for nm in "${node_modules[@]}"; do
-    rm -Rf "$nm.bundled"
-    mv "$nm" "$nm.bundled"
-  done
+  # We remove the scripts field so that later on we can run
+  # yarn to fetch node_modules if necessary without build scripts running.
+  # We cannot use --no-scripts because we still want dependant package scripts to run.
+  jq 'del(.scripts)' < "$VSCODE_SRC_PATH/package.json" > "$VSCODE_OUT_PATH/package.json"
 }
 
 main "$@"

--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -24,24 +24,18 @@ main() {
     ;;
   esac
 
-  cd lib/vscode
-
-  # We have to rename node_modules.bundled to node_modules.
-  # The bundled modules were renamed originally to avoid being ignored by yarn.
-  node_modules="$(find . -depth -name "node_modules.bundled")"
-  for nm in $node_modules; do
-    rm -Rf "${nm%.bundled}"
-    mv "$nm" "${nm%.bundled}"
-  done
-
-  # $npm_config_global makes npm rebuild return without rebuilding.
-  unset npm_config_global
-  # Rebuilds native modules.
-  if ! npm rebuild; then
+  if ! vscode_yarn; then
     echo "You may not have the required dependencies to build the native modules."
     echo "Please see https://github.com/cdr/code-server/blob/master/doc/npm.md"
     exit 1
   fi
+}
+
+vscode_yarn() {
+  cd lib/vscode
+  yarn --production --frozen-lockfile
+  cd extensions
+  yarn --production --frozen-lockfile
 }
 
 main "$@"

--- a/ci/build/release-github-draft.sh
+++ b/ci/build/release-github-draft.sh
@@ -9,6 +9,7 @@ main() {
 
   hub release create \
     --file - \
+    -t "$(git rev-parse HEAD)" \
     --draft "${assets[@]}" "v$VERSION" << EOF
 v$VERSION
 

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -82,8 +82,8 @@ SSH into your instance and run the appropriate commands documented in [README.md
 Assuming Debian:
 
 ```bash
-curl -sSOL https://github.com/cdr/code-server/releases/download/v3.3.0/code-server_3.3.0_amd64.deb
-sudo dpkg -i code-server_3.3.0_amd64.deb
+curl -sSOL https://github.com/cdr/code-server/releases/download/v3.3.1/code-server_3.3.1_amd64.deb
+sudo dpkg -i code-server_3.3.1_amd64.deb
 systemctl --user enable --now code-server
 # Now code-server is running at http://127.0.0.1:8080
 # Your password is in ~/.config/code-server/config.yaml

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/cdr/code-server",
   "bugs": {


### PR DESCRIPTION
This release fixes bugs introduced with the release of v3.3.0

- We've reverted to VS Code 1.45.1 due to bugs in 1.46 #1667
- Accessing code-server from a web browser on Windows has been fixed #1642
- Search in project has been fixed #1665
- The glibc requirement on static releases has been lowered to v2.19 #1656


<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.
-->