### PR TITLE
v3.4.1

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -16,7 +16,7 @@ Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) 
 
 1. Update the version of code-server and make a PR.
    1. Update in `package.json`
-   2. Update in [install.sh](../install.sh)
+   2. Update in [./doc/install.md](../doc/install.md)
 2. GitHub actions will generate the `npm-package`, `release-packages` and `release-images` artifacts.
 3. Run `yarn release:github-draft` to create a GitHub draft release from the template with
    the updated version.

--- a/doc/install.md
+++ b/doc/install.md
@@ -77,8 +77,8 @@ commands presented in the rest of this document.
 ## Debian, Ubuntu
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.4.0/code-server_3.4.0_amd64.deb
-sudo dpkg -i code-server_3.4.0_amd64.deb
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.4.1/code-server_3.4.1_amd64.deb
+sudo dpkg -i code-server_3.4.1_amd64.deb
 systemctl --user enable --now code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -86,8 +86,8 @@ systemctl --user enable --now code-server
 ## Fedora, CentOS, RHEL, SUSE
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.4.0/code-server-3.4.0-amd64.rpm
-sudo rpm -i code-server-3.4.0-amd64.rpm
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.4.1/code-server-3.4.1-amd64.rpm
+sudo rpm -i code-server-3.4.1-amd64.rpm
 systemctl --user enable --now code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -115,7 +115,7 @@ systemctl --user enable --now code-server
 We recommend installing with `yarn` or `npm` when:
 
 1. You aren't on `amd64` or `arm64`.
-2. If you're on Linux with glibc < v2.17
+2. If you're on Linux with glibc < v2.17 or glibcxx < v3.4.18
 
 **note:** Installing via `yarn` or `npm` builds native modules on install and so requires C dependencies.
 See [./npm.md](./npm.md) for installing these dependencies.
@@ -143,7 +143,7 @@ We publish self contained `.tar.gz` archives for every release on [github](https
 They bundle the node binary and `node_modules`.
 
 These are created from the [npm package](#yarn-npm) and the rest of the releases are created from these.
-Only requirement is glibc >= 2.17 on Linux and for macOS there is no minimum system requirement.
+Only requirement is glibc >= 2.17 && glibcxx >= v3.4.18 on Linux and for macOS there is no minimum system requirement.
 
 1. Download the latest release archive for your system from [github](https://github.com/cdr/code-server/releases).
 2. Unpack the release.
@@ -156,10 +156,10 @@ Here is an example script for installing and using a standalone `code-server` re
 
 ```bash
 mkdir -p ~/.local/lib ~/.local/bin
-curl -fL https://github.com/cdr/code-server/releases/download/v3.4.0/code-server-3.4.0-linux-amd64.tar.gz \
+curl -fL https://github.com/cdr/code-server/releases/download/v3.4.1/code-server-3.4.1-linux-amd64.tar.gz \
   | tar -C ~/.local/lib -xz
-mv ~/.local/lib/code-server-3.4.0-linux-amd64 ~/.local/lib/code-server-3.4.0
-ln -s ~/.local/lib/code-server-3.4.0/bin/code-server ~/.local/bin/code-server
+mv ~/.local/lib/code-server-3.4.1-linux-amd64 ~/.local/lib/code-server-3.4.1
+ln -s ~/.local/lib/code-server-3.4.1/bin/code-server ~/.local/bin/code-server
 PATH="~/.local/bin:$PATH"
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/cdr/code-server",
   "bugs": {


### PR DESCRIPTION
VS Code v1.45.1

# Bug Fixes

- Hopefully this one fixes autoupdates from `3.2.0` once and for all.
   - We're now publishing duplicate releases without the `v` prefix so that auto updates from `3.2.0` work. See #1746 and #1758 for background.
   - Note there is no auto updating in any of the recent releases including this one.

- The config file's `extension-dir` and `data-dir` parameters are now properly obeyed #1750
   - This was supposed to be fixed in the last release but because of a subtle bug it turned out it was printing the correct directories but not actually using them.
   - It should now use `extension-dir` and `data-dir` as set in the config file

- We do not bundle any dynamic libraries in releases anymore #1738
   - It was causing bizarre issues for users and we couldn't make it work perfectly.
   - On Linux we now compile on CentOS 7 so that the minimum glibc version is v2.17 and glibcxx is v3.4.18
   - On macOS we now pull in a fully static release of node.

- Using the deprecated root `code-server` symlink now warns on usage that it will be removed in the next few weeks.
   - The entry script now also handles recursive symlinks correctly.

- `globalStorageHome` is now created on startup #1693 so that extensions that rely on it being there should work now