### PR TITLE
Add FreeBSD support for an npm based install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -360,6 +360,9 @@ os() {
   Darwin)
     echo macos
     ;;
+  FreeBSD)
+    echo freebsd
+    ;;
   esac
 }
 


### PR DESCRIPTION
With this small change code-server can be installed via npm on a FreeBSD amd64 install.
