### PR TITLE
feat: persist route query to local

### DIFF
--- a/src/node/app/vscode.ts
+++ b/src/node/app/vscode.ts
@@ -183,14 +183,9 @@ export class VscodeHttpProvider extends HttpProvider {
       }),
     ])
 
-    let promise = Promise.resolve()
-    if (startPath) {
-      promise = settings.write({ lastVisited: startPath })
-    }
-    // `settings.write` depends on `settings.read` internally. To avoid race conditions, a promise is added here to synchronize.
-    promise.then(() => {
-      // the query should not be extends, but should be replaced directly.
-      settings.write({ query: route.query }, true)
+    settings.write({
+      lastVisited: startPath || lastVisited, // If startpath is undefined, then fallback to lastVisited
+      query: route.query,
     })
 
     if (!this.isDev) {

--- a/src/node/app/vscode.ts
+++ b/src/node/app/vscode.ts
@@ -134,6 +134,7 @@ export class VscodeHttpProvider extends HttpProvider {
           return { redirect: "/login", query: { to: this.options.base } }
         }
         try {
+          this.persistRouteQuery(request, route)
           return await this.getRoot(request, route)
         } catch (error) {
           const message = `<div>VS Code failed to load.</div> ${
@@ -163,6 +164,13 @@ export class VscodeHttpProvider extends HttpProvider {
     }
 
     throw new HttpError("Not found", HttpCode.NotFound)
+  }
+  
+  private persistRouteQuery(request: http.IncomingMessage, route: Route): void {
+    const content = Object.keys(route.query).reduce((content, next) => {
+      return (content += `${next}=${route.query[next]}\n`)
+    }, "")
+    fs.writeFile(path.resolve(paths.data, "query"), content)
   }
 
   private async getRoot(request: http.IncomingMessage, route: Route): Promise<HttpResponse> {

--- a/src/node/settings.ts
+++ b/src/node/settings.ts
@@ -30,9 +30,9 @@ export class SettingsProvider<T> {
 
   /**
    * Write settings combined with current settings. On failure log a warning.
-   * Objects will be merged and everything else will be replaced.
+   * Settings can be shallow or deep merged.
    */
-  public async write(settings: Partial<T>, shallow?: boolean): Promise<void> {
+  public async write(settings: Partial<T>, shallow = true): Promise<void> {
     try {
       const oldSettings = await this.read()
       const nextSettings = shallow ? Object.assign({}, oldSettings, settings) : extend(oldSettings, settings)

--- a/src/node/settings.ts
+++ b/src/node/settings.ts
@@ -2,6 +2,7 @@ import * as fs from "fs-extra"
 import * as path from "path"
 import { extend, paths } from "./util"
 import { logger } from "@coder/logger"
+import { Route } from "./http"
 
 export type Settings = { [key: string]: Settings | string | boolean | number }
 
@@ -31,9 +32,11 @@ export class SettingsProvider<T> {
    * Write settings combined with current settings. On failure log a warning.
    * Objects will be merged and everything else will be replaced.
    */
-  public async write(settings: Partial<T>): Promise<void> {
+  public async write(settings: Partial<T>, shallow?: boolean): Promise<void> {
     try {
-      await fs.writeFile(this.settingsPath, JSON.stringify(extend(await this.read(), settings), null, 2))
+      const oldSettings = await this.read()
+      const nextSettings = shallow ? Object.assign({}, oldSettings, settings) : extend(oldSettings, settings)
+      await fs.writeFile(this.settingsPath, JSON.stringify(nextSettings, null, 2))
     } catch (error) {
       logger.warn(error.message)
     }
@@ -55,6 +58,7 @@ export interface CoderSettings extends UpdateSettings {
     url: string
     workspace: boolean
   }
+  query: Route["query"]
 }
 
 /**


### PR DESCRIPTION
Provide a way for the shell script running in the docker container to get the url query.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.
-->
