### PR TITLE
Simplify HttpError

### DIFF
--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -9,7 +9,7 @@ export enum HttpCode {
 }
 
 export class HttpError extends Error {
-  public constructor(message: string, public readonly code: number, public readonly details?: object) {
+  constructor(message: string, public readonly code: number) {
     super(message)
     this.name = this.constructor.name
   }


### PR DESCRIPTION
This change is cosmetic (issue not linked due to being extremely minor). As part of reading the codebase for the first time, I noticed `details` is not used anywhere.

* Remove public keyword - public by default
* Remove details - this was unused throughout the entire codebase
