### PR TITLE
Add Callback type

### DIFF
--- a/src/common/emitter.ts
+++ b/src/common/emitter.ts
@@ -1,19 +1,21 @@
+import { Callback } from "./types"
+
 export interface Disposable {
   dispose(): void
 }
 
 export interface Event<T> {
-  (listener: (value: T) => void): Disposable
+  (listener: Callback<T>): Disposable
 }
 
 /**
  * Emitter typecasts for a single event type.
  */
 export class Emitter<T> {
-  private listeners: Array<(value: T) => void> = []
+  private listeners: Array<Callback<T>> = []
 
   public get event(): Event<T> {
-    return (cb: (value: T) => void): Disposable => {
+    return (cb: Callback<T>): Disposable => {
       this.listeners.push(cb)
 
       return {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,0 +1,1 @@
+export type Callback<T, R = void> = (t: T) => R


### PR DESCRIPTION
Adds a reusable Callback type that is applied to emitter.ts for improved readability/simplicity. Issue not linked because the change is minor.