### PR TITLE
Update 'plural' common util

### DIFF
--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -16,7 +16,11 @@ export const split = (str: string, delimiter: string): [string, string] => {
   return index !== -1 ? [str.substring(0, index).trim(), str.substring(index + 1)] : [str, ""]
 }
 
-export const plural = (count: number): string => (count === 1 ? "" : "s")
+/**
+ * Appends an 's' to the provided string if count is greater than one;
+ * otherwise the string is returned
+ */
+export const plural = (count: number, str: string): string => (count === 1 ? str : `${str}s`)
 
 export const generateUuid = (length = 24): string => {
   const possible = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -11,6 +11,7 @@ import { Args, bindAddrFromAllSources, optionDescriptions, parse, readConfigFile
 import { AuthType, HttpServer, HttpServerOptions } from "./http"
 import { generateCertificate, hash, open, humanPath } from "./util"
 import { ipcMain, wrap } from "./wrapper"
+import { plural } from "../common/util"
 
 process.on("uncaughtException", (error) => {
   logger.error(`Uncaught exception: ${error.message}`)
@@ -110,7 +111,7 @@ const main = async (args: Args, cliArgs: Args, configArgs: Args): Promise<void> 
   }
 
   if (httpServer.proxyDomains.size > 0) {
-    logger.info(`  - Proxying the following domain${httpServer.proxyDomains.size === 1 ? "" : "s"}:`)
+    logger.info(`  - ${plural(httpServer.proxyDomains.size, "Proxying the following domain")}:`)
     httpServer.proxyDomains.forEach((domain) => logger.info(`    - *.${domain}`))
   }
 

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -481,7 +481,7 @@ export class HttpServer {
     this.proxyDomains = new Set((options.proxyDomains || []).map((d) => d.replace(/^\*\./, "")))
     this.heart = new Heart(path.join(paths.data, "heartbeat"), async () => {
       const connections = await this.getConnections()
-      logger.trace(`${connections} active connection${plural(connections)}`)
+      logger.trace(plural(connections, `${connections} active connection`))
       return connections !== 0
     })
     this.protocol = this.options.cert ? "https" : "http"


### PR DESCRIPTION
Adds a str param to `common/util::plural` for pluralizing a string.
Applies plural to entry.ts.

No linked issued; update is sufficiently minor.