### PR TITLE
Allow opening files, folders, and workspaces in existing code-server from CLI

### DIFF
--- a/ci/dev/vscode.patch
+++ b/ci/dev/vscode.patch
@@ -1296,6 +1296,17 @@ index 0000000000..16ed214d94
 +	type: 'cli';
 +	args: Args;
 +}
++ export interface OpenCommandPipeArgs {
++	type: 'open';
++	fileURIs?: string[];
++	folderURIs: string[];
++	forceNewWindow?: boolean;
++	diffMode?: boolean;
++	addMode?: boolean;
++	gotoLineMode?: boolean;
++	forceReuseWindow?: boolean;
++	waitMarkerFilePath?: string;
++ }
 +
 +export type CodeServerMessage = InitMessage | SocketMessage | CliMessage;
 +

--- a/ci/dev/vscode.patch
+++ b/ci/dev/vscode.patch
@@ -1,5 +1,5 @@
 diff --git a/.gitignore b/.gitignore
-index 0fe46b6ead..e545e004ce 100644
+index 0fe46b6eadc..e545e004cef 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -25,7 +25,6 @@ out-vscode-reh-web-pkg/
@@ -12,7 +12,7 @@ index 0fe46b6ead..e545e004ce 100644
  coverage/
 diff --git a/.yarnrc b/.yarnrc
 deleted file mode 100644
-index 135e10442a..0000000000
+index 135e10442a7..00000000000
 --- a/.yarnrc
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -20,7 +20,7 @@ index 135e10442a..0000000000
 -target "7.3.2"
 -runtime "electron"
 diff --git a/build/gulpfile.reh.js b/build/gulpfile.reh.js
-index f2ea1bd370..3f660f9981 100644
+index f2ea1bd3701..3f660f99819 100644
 --- a/build/gulpfile.reh.js
 +++ b/build/gulpfile.reh.js
 @@ -52,6 +52,7 @@ gulp.task('vscode-reh-web-linux-x64-min', noop);
@@ -32,7 +32,7 @@ index f2ea1bd370..3f660f9981 100644
  	const target = /^target "(.*)"$/m.exec(yarnrc)[1];
  	return target;
 diff --git a/build/lib/node.js b/build/lib/node.js
-index 403ae3d965..738ee8cee0 100644
+index 403ae3d9657..738ee8cee0e 100644
 --- a/build/lib/node.js
 +++ b/build/lib/node.js
 @@ -5,11 +5,8 @@
@@ -49,7 +49,7 @@ index 403ae3d965..738ee8cee0 100644
  const nodePath = path.join(root, '.build', 'node', `v${version}`, `${process.platform}-${process.arch}`, node);
  console.log(nodePath);
 diff --git a/build/lib/node.ts b/build/lib/node.ts
-index 6439703446..c53dccf4dc 100644
+index 64397034461..c53dccf4dc0 100644
 --- a/build/lib/node.ts
 +++ b/build/lib/node.ts
 @@ -4,13 +4,10 @@
@@ -70,7 +70,7 @@ index 6439703446..c53dccf4dc 100644
 \ No newline at end of file
 +console.log(nodePath);
 diff --git a/build/lib/util.js b/build/lib/util.js
-index e552a036f8..169e8614b9 100644
+index e552a036f89..169e8614b9f 100644
 --- a/build/lib/util.js
 +++ b/build/lib/util.js
 @@ -257,6 +257,7 @@ function streamToPromise(stream) {
@@ -82,7 +82,7 @@ index e552a036f8..169e8614b9 100644
      const target = /^target "(.*)"$/m.exec(yarnrc)[1];
      return target;
 diff --git a/build/lib/util.ts b/build/lib/util.ts
-index 035c7e95ea..4ff8dcfe6b 100644
+index 035c7e95ea3..4ff8dcfe6b2 100644
 --- a/build/lib/util.ts
 +++ b/build/lib/util.ts
 @@ -322,6 +322,7 @@ export function streamToPromise(stream: NodeJS.ReadWriteStream): Promise<void> {
@@ -94,7 +94,7 @@ index 035c7e95ea..4ff8dcfe6b 100644
  	const target = /^target "(.*)"$/m.exec(yarnrc)![1];
  	return target;
 diff --git a/build/npm/postinstall.js b/build/npm/postinstall.js
-index 8f8b0019a7..ea054c725b 100644
+index 8f8b0019a77..ea054c725be 100644
 --- a/build/npm/postinstall.js
 +++ b/build/npm/postinstall.js
 @@ -33,10 +33,11 @@ function yarnInstall(location, opts) {
@@ -127,7 +127,7 @@ index 8f8b0019a7..ea054c725b 100644
  
  cp.execSync('git config pull.rebase true');
 diff --git a/build/npm/preinstall.js b/build/npm/preinstall.js
-index cb88d37ade..6b3253af0a 100644
+index cb88d37adef..6b3253af0a3 100644
 --- a/build/npm/preinstall.js
 +++ b/build/npm/preinstall.js
 @@ -8,8 +8,9 @@ let err = false;
@@ -144,7 +144,7 @@ index cb88d37ade..6b3253af0a 100644
  const cp = require('child_process');
 diff --git a/coder.js b/coder.js
 new file mode 100644
-index 0000000000..9cb693af63
+index 00000000000..9cb693af63b
 --- /dev/null
 +++ b/coder.js
 @@ -0,0 +1,63 @@
@@ -212,7 +212,7 @@ index 0000000000..9cb693af63
 +	common.minifyTask("out-vscode")
 +));
 diff --git a/extensions/postinstall.js b/extensions/postinstall.js
-index da4fa3e9d0..50f3e1144f 100644
+index da4fa3e9d04..50f3e1144f8 100644
 --- a/extensions/postinstall.js
 +++ b/extensions/postinstall.js
 @@ -24,6 +24,9 @@ function processRoot() {
@@ -226,7 +226,7 @@ index da4fa3e9d0..50f3e1144f 100644
  
  function processLib() {
 diff --git a/package.json b/package.json
-index 226f51a1ec..5c4e5af5f6 100644
+index 226f51a1ec5..5c4e5af5f69 100644
 --- a/package.json
 +++ b/package.json
 @@ -45,7 +45,11 @@
@@ -267,7 +267,7 @@ index 226f51a1ec..5c4e5af5f6 100644
    }
  }
 diff --git a/product.json b/product.json
-index 2b884d18f3..518b935b83 100644
+index 2b884d18f30..518b935b837 100644
 --- a/product.json
 +++ b/product.json
 @@ -20,7 +20,7 @@
@@ -281,7 +281,7 @@ index 2b884d18f3..518b935b83 100644
  		"ms-vscode.vscode-js-profile-flame",
 diff --git a/remote/.yarnrc b/remote/.yarnrc
 deleted file mode 100644
-index 1e16cde724..0000000000
+index 1e16cde724c..00000000000
 --- a/remote/.yarnrc
 +++ /dev/null
 @@ -1,3 +0,0 @@
@@ -289,7 +289,7 @@ index 1e16cde724..0000000000
 -target "12.4.0"
 -runtime "node"
 diff --git a/src/vs/base/common/network.ts b/src/vs/base/common/network.ts
-index 1286c5117a..e60dd11d03 100644
+index 1286c5117a4..e60dd11d039 100644
 --- a/src/vs/base/common/network.ts
 +++ b/src/vs/base/common/network.ts
 @@ -111,16 +111,17 @@ class RemoteAuthoritiesImpl {
@@ -314,7 +314,7 @@ index 1286c5117a..e60dd11d03 100644
  		});
  	}
 diff --git a/src/vs/base/common/platform.ts b/src/vs/base/common/platform.ts
-index 0bbc5d6ef9..61f139b9c5 100644
+index 0bbc5d6ef91..61f139b9c55 100644
 --- a/src/vs/base/common/platform.ts
 +++ b/src/vs/base/common/platform.ts
 @@ -59,6 +59,17 @@ if (typeof navigator === 'object' && !isElectronRenderer) {
@@ -336,7 +336,7 @@ index 0bbc5d6ef9..61f139b9c5 100644
  	_isWindows = (process.platform === 'win32');
  	_isMacintosh = (process.platform === 'darwin');
 diff --git a/src/vs/base/common/processes.ts b/src/vs/base/common/processes.ts
-index c52f7b3774..08a87fa970 100644
+index c52f7b3774f..08a87fa970f 100644
 --- a/src/vs/base/common/processes.ts
 +++ b/src/vs/base/common/processes.ts
 @@ -110,7 +110,8 @@ export function sanitizeProcessEnvironment(env: IProcessEnvironment, ...preserve
@@ -350,7 +350,7 @@ index c52f7b3774..08a87fa970 100644
  	const envKeys = Object.keys(env);
  	envKeys
 diff --git a/src/vs/base/common/uriIpc.ts b/src/vs/base/common/uriIpc.ts
-index ef2291d49b..29b2f9dfc2 100644
+index ef2291d49b1..29b2f9dfc2b 100644
 --- a/src/vs/base/common/uriIpc.ts
 +++ b/src/vs/base/common/uriIpc.ts
 @@ -5,6 +5,7 @@
@@ -416,7 +416,7 @@ index ef2291d49b..29b2f9dfc2 100644
 \ No newline at end of file
 +}
 diff --git a/src/vs/base/node/languagePacks.js b/src/vs/base/node/languagePacks.js
-index 2c64061da7..c0ef8faedd 100644
+index 2c64061da7b..c0ef8faedd4 100644
 --- a/src/vs/base/node/languagePacks.js
 +++ b/src/vs/base/node/languagePacks.js
 @@ -128,7 +128,10 @@ function factory(nodeRequire, path, fs, perf) {
@@ -432,7 +432,7 @@ index 2c64061da7..c0ef8faedd 100644
  			// Do nothing. If we can't read the file we have no
  			// language pack config.
 diff --git a/src/vs/code/browser/workbench/workbench.ts b/src/vs/code/browser/workbench/workbench.ts
-index c629f7fffa..c266e1fb06 100644
+index c629f7fffa1..c266e1fb06f 100644
 --- a/src/vs/code/browser/workbench/workbench.ts
 +++ b/src/vs/code/browser/workbench/workbench.ts
 @@ -13,6 +13,8 @@ import { isFolderToOpen, isWorkspaceToOpen } from 'vs/platform/windows/common/wi
@@ -532,7 +532,7 @@ index c629f7fffa..c266e1fb06 100644
  	// If no workspace is provided through the URL, check for config attribute from server
  	if (!foundWorkspace) {
 diff --git a/src/vs/platform/environment/node/argv.ts b/src/vs/platform/environment/node/argv.ts
-index 2379b626c8..28f8971cf3 100644
+index 2379b626c81..28f8971cf39 100644
 --- a/src/vs/platform/environment/node/argv.ts
 +++ b/src/vs/platform/environment/node/argv.ts
 @@ -8,6 +8,8 @@ import { localize } from 'vs/nls';
@@ -559,7 +559,7 @@ index 2379b626c8..28f8971cf3 100644
  }
 -
 diff --git a/src/vs/platform/environment/node/environmentService.ts b/src/vs/platform/environment/node/environmentService.ts
-index 5c0dc4ad4a..38b8c7573a 100644
+index 5c0dc4ad4ae..38b8c7573a8 100644
 --- a/src/vs/platform/environment/node/environmentService.ts
 +++ b/src/vs/platform/environment/node/environmentService.ts
 @@ -38,6 +38,8 @@ export interface INativeEnvironmentService extends IEnvironmentService {
@@ -586,7 +586,7 @@ index 5c0dc4ad4a..38b8c7573a 100644
  	get extensionDevelopmentLocationURI(): URI[] | undefined {
  		const s = this._args.extensionDevelopmentPath;
 diff --git a/src/vs/platform/extensionManagement/node/extensionsScanner.ts b/src/vs/platform/extensionManagement/node/extensionsScanner.ts
-index 575b2aafc3..873181f967 100644
+index 575b2aafc38..873181f9678 100644
 --- a/src/vs/platform/extensionManagement/node/extensionsScanner.ts
 +++ b/src/vs/platform/extensionManagement/node/extensionsScanner.ts
 @@ -85,7 +85,7 @@ export class ExtensionsScanner extends Disposable {
@@ -633,7 +633,7 @@ index 575b2aafc3..873181f967 100644
 +	}
  }
 diff --git a/src/vs/platform/product/common/product.ts b/src/vs/platform/product/common/product.ts
-index 3370a608b4..37b3592d39 100644
+index 3370a608b4b..37b3592d39d 100644
 --- a/src/vs/platform/product/common/product.ts
 +++ b/src/vs/platform/product/common/product.ts
 @@ -30,6 +30,12 @@ if (isWeb) {
@@ -650,7 +650,7 @@ index 3370a608b4..37b3592d39 100644
  
  // Node: AMD loader
 diff --git a/src/vs/platform/product/common/productService.ts b/src/vs/platform/product/common/productService.ts
-index 040c869d94..bf16defcf7 100644
+index 040c869d94c..bf16defcf7b 100644
 --- a/src/vs/platform/product/common/productService.ts
 +++ b/src/vs/platform/product/common/productService.ts
 @@ -30,6 +30,8 @@ export type ConfigurationSyncStore = {
@@ -663,7 +663,7 @@ index 040c869d94..bf16defcf7 100644
  	readonly date?: string;
  	readonly quality?: string;
 diff --git a/src/vs/platform/remote/browser/browserSocketFactory.ts b/src/vs/platform/remote/browser/browserSocketFactory.ts
-index 3715cbb8e6..c65de8ad37 100644
+index 3715cbb8e6e..c65de8ad37e 100644
 --- a/src/vs/platform/remote/browser/browserSocketFactory.ts
 +++ b/src/vs/platform/remote/browser/browserSocketFactory.ts
 @@ -208,7 +208,8 @@ export class BrowserSocketFactory implements ISocketFactory {
@@ -684,7 +684,7 @@ index 3715cbb8e6..c65de8ad37 100644
 -
 -
 diff --git a/src/vs/platform/remote/common/remoteAgentConnection.ts b/src/vs/platform/remote/common/remoteAgentConnection.ts
-index 2185bb5228..35463ca652 100644
+index 2185bb5228c..35463ca6520 100644
 --- a/src/vs/platform/remote/common/remoteAgentConnection.ts
 +++ b/src/vs/platform/remote/common/remoteAgentConnection.ts
 @@ -89,7 +89,7 @@ async function connectToRemoteExtensionHostAgent(options: ISimpleConnectionOptio
@@ -698,7 +698,7 @@ index 2185bb5228..35463ca652 100644
  					options.logService.error(`${logPrefix} socketFactory.connect() failed. Error:`);
 diff --git a/src/vs/server/browser/client.ts b/src/vs/server/browser/client.ts
 new file mode 100644
-index 0000000000..3c0703b717
+index 00000000000..3c0703b7174
 --- /dev/null
 +++ b/src/vs/server/browser/client.ts
 @@ -0,0 +1,189 @@
@@ -893,7 +893,7 @@ index 0000000000..3c0703b717
 +};
 diff --git a/src/vs/server/browser/extHostNodeProxy.ts b/src/vs/server/browser/extHostNodeProxy.ts
 new file mode 100644
-index 0000000000..ed7c078077
+index 00000000000..ed7c078077b
 --- /dev/null
 +++ b/src/vs/server/browser/extHostNodeProxy.ts
 @@ -0,0 +1,46 @@
@@ -945,7 +945,7 @@ index 0000000000..ed7c078077
 +export const IExtHostNodeProxy = createDecorator<IExtHostNodeProxy>('IExtHostNodeProxy');
 diff --git a/src/vs/server/browser/mainThreadNodeProxy.ts b/src/vs/server/browser/mainThreadNodeProxy.ts
 new file mode 100644
-index 0000000000..0d2e93edae
+index 00000000000..0d2e93edae2
 --- /dev/null
 +++ b/src/vs/server/browser/mainThreadNodeProxy.ts
 @@ -0,0 +1,37 @@
@@ -988,7 +988,7 @@ index 0000000000..0d2e93edae
 +}
 diff --git a/src/vs/server/browser/worker.ts b/src/vs/server/browser/worker.ts
 new file mode 100644
-index 0000000000..5ae44cdc85
+index 00000000000..5ae44cdc856
 --- /dev/null
 +++ b/src/vs/server/browser/worker.ts
 @@ -0,0 +1,56 @@
@@ -1050,7 +1050,7 @@ index 0000000000..5ae44cdc85
 +};
 diff --git a/src/vs/server/common/nodeProxy.ts b/src/vs/server/common/nodeProxy.ts
 new file mode 100644
-index 0000000000..14b9de879c
+index 00000000000..14b9de879ce
 --- /dev/null
 +++ b/src/vs/server/common/nodeProxy.ts
 @@ -0,0 +1,47 @@
@@ -1103,7 +1103,7 @@ index 0000000000..14b9de879c
 +}
 diff --git a/src/vs/server/common/telemetry.ts b/src/vs/server/common/telemetry.ts
 new file mode 100644
-index 0000000000..4ea6d95d36
+index 00000000000..4ea6d95d36a
 --- /dev/null
 +++ b/src/vs/server/common/telemetry.ts
 @@ -0,0 +1,65 @@
@@ -1174,7 +1174,7 @@ index 0000000000..4ea6d95d36
 +}
 diff --git a/src/vs/server/entry.ts b/src/vs/server/entry.ts
 new file mode 100644
-index 0000000000..ab020fbb4e
+index 00000000000..ab020fbb4e4
 --- /dev/null
 +++ b/src/vs/server/entry.ts
 @@ -0,0 +1,78 @@
@@ -1258,7 +1258,7 @@ index 0000000000..ab020fbb4e
 +}
 diff --git a/src/vs/server/fork.js b/src/vs/server/fork.js
 new file mode 100644
-index 0000000000..56331ff1fc
+index 00000000000..56331ff1fc3
 --- /dev/null
 +++ b/src/vs/server/fork.js
 @@ -0,0 +1,3 @@
@@ -1267,10 +1267,10 @@ index 0000000000..56331ff1fc
 +require('../../bootstrap-amd').load('vs/server/entry');
 diff --git a/src/vs/server/ipc.d.ts b/src/vs/server/ipc.d.ts
 new file mode 100644
-index 0000000000..16ed214d94
+index 00000000000..33b28cf2d53
 --- /dev/null
 +++ b/src/vs/server/ipc.d.ts
-@@ -0,0 +1,119 @@
+@@ -0,0 +1,131 @@
 +/**
 + * External interfaces for integration into code-server over IPC. No vs imports
 + * should be made in this file.
@@ -1296,7 +1296,8 @@ index 0000000000..16ed214d94
 +	type: 'cli';
 +	args: Args;
 +}
-+ export interface OpenCommandPipeArgs {
++
++export interface OpenCommandPipeArgs {
 +	type: 'open';
 +	fileURIs?: string[];
 +	folderURIs: string[];
@@ -1306,7 +1307,7 @@ index 0000000000..16ed214d94
 +	gotoLineMode?: boolean;
 +	forceReuseWindow?: boolean;
 +	waitMarkerFilePath?: string;
-+ }
++}
 +
 +export type CodeServerMessage = InitMessage | SocketMessage | CliMessage;
 +
@@ -1403,7 +1404,7 @@ index 0000000000..16ed214d94
 +}
 diff --git a/src/vs/server/node/channel.ts b/src/vs/server/node/channel.ts
 new file mode 100644
-index 0000000000..e10cc9c218
+index 00000000000..e10cc9c218b
 --- /dev/null
 +++ b/src/vs/server/node/channel.ts
 @@ -0,0 +1,360 @@
@@ -1769,7 +1770,7 @@ index 0000000000..e10cc9c218
 +}
 diff --git a/src/vs/server/node/connection.ts b/src/vs/server/node/connection.ts
 new file mode 100644
-index 0000000000..36e80fb696
+index 00000000000..36e80fb6966
 --- /dev/null
 +++ b/src/vs/server/node/connection.ts
 @@ -0,0 +1,157 @@
@@ -1932,7 +1933,7 @@ index 0000000000..36e80fb696
 +}
 diff --git a/src/vs/server/node/insights.ts b/src/vs/server/node/insights.ts
 new file mode 100644
-index 0000000000..a0ece345f2
+index 00000000000..a0ece345f28
 --- /dev/null
 +++ b/src/vs/server/node/insights.ts
 @@ -0,0 +1,124 @@
@@ -2062,7 +2063,7 @@ index 0000000000..a0ece345f2
 +}
 diff --git a/src/vs/server/node/ipc.ts b/src/vs/server/node/ipc.ts
 new file mode 100644
-index 0000000000..5e560eb46e
+index 00000000000..5e560eb46e6
 --- /dev/null
 +++ b/src/vs/server/node/ipc.ts
 @@ -0,0 +1,61 @@
@@ -2129,7 +2130,7 @@ index 0000000000..5e560eb46e
 +export const ipcMain = new IpcMain();
 diff --git a/src/vs/server/node/logger.ts b/src/vs/server/node/logger.ts
 new file mode 100644
-index 0000000000..2a39c524aa
+index 00000000000..2a39c524aaa
 --- /dev/null
 +++ b/src/vs/server/node/logger.ts
 @@ -0,0 +1,2 @@
@@ -2137,7 +2138,7 @@ index 0000000000..2a39c524aa
 +export const logger = baseLogger.named('vscode');
 diff --git a/src/vs/server/node/marketplace.ts b/src/vs/server/node/marketplace.ts
 new file mode 100644
-index 0000000000..8956fc40d4
+index 00000000000..8956fc40d48
 --- /dev/null
 +++ b/src/vs/server/node/marketplace.ts
 @@ -0,0 +1,174 @@
@@ -2317,7 +2318,7 @@ index 0000000000..8956fc40d4
 +};
 diff --git a/src/vs/server/node/nls.ts b/src/vs/server/node/nls.ts
 new file mode 100644
-index 0000000000..3d428a57d3
+index 00000000000..3d428a57d31
 --- /dev/null
 +++ b/src/vs/server/node/nls.ts
 @@ -0,0 +1,88 @@
@@ -2411,7 +2412,7 @@ index 0000000000..3d428a57d3
 +};
 diff --git a/src/vs/server/node/protocol.ts b/src/vs/server/node/protocol.ts
 new file mode 100644
-index 0000000000..3c74512192
+index 00000000000..3c74512192a
 --- /dev/null
 +++ b/src/vs/server/node/protocol.ts
 @@ -0,0 +1,73 @@
@@ -2490,7 +2491,7 @@ index 0000000000..3c74512192
 +}
 diff --git a/src/vs/server/node/server.ts b/src/vs/server/node/server.ts
 new file mode 100644
-index 0000000000..4b88fedb2f
+index 00000000000..4b88fedb2f0
 --- /dev/null
 +++ b/src/vs/server/node/server.ts
 @@ -0,0 +1,285 @@
@@ -2781,7 +2782,7 @@ index 0000000000..4b88fedb2f
 +}
 diff --git a/src/vs/server/node/util.ts b/src/vs/server/node/util.ts
 new file mode 100644
-index 0000000000..fa47e993b4
+index 00000000000..fa47e993b46
 --- /dev/null
 +++ b/src/vs/server/node/util.ts
 @@ -0,0 +1,13 @@
@@ -2799,7 +2800,7 @@ index 0000000000..fa47e993b4
 +	return path.split("/").map((p) => encodeURIComponent(p)).join("/");
 +};
 diff --git a/src/vs/workbench/api/browser/extensionHost.contribution.ts b/src/vs/workbench/api/browser/extensionHost.contribution.ts
-index 3d77009b90..11deb1b99a 100644
+index 3d77009b908..11deb1b99ac 100644
 --- a/src/vs/workbench/api/browser/extensionHost.contribution.ts
 +++ b/src/vs/workbench/api/browser/extensionHost.contribution.ts
 @@ -60,6 +60,7 @@ import './mainThreadComments';
@@ -2811,7 +2812,7 @@ index 3d77009b90..11deb1b99a 100644
  import './mainThreadAuthentication';
  import './mainThreadTimeline';
 diff --git a/src/vs/workbench/api/common/extHost.api.impl.ts b/src/vs/workbench/api/common/extHost.api.impl.ts
-index 97793666ad..13cd137db1 100644
+index 97793666ad8..13cd137db1e 100644
 --- a/src/vs/workbench/api/common/extHost.api.impl.ts
 +++ b/src/vs/workbench/api/common/extHost.api.impl.ts
 @@ -68,6 +68,7 @@ import { IURITransformerService } from 'vs/workbench/api/common/extHostUriTransf
@@ -2839,7 +2840,7 @@ index 97793666ad..13cd137db1 100644
  	rpcProtocol.set(ExtHostContext.ExtHostWindow, extHostWindow);
  
 diff --git a/src/vs/workbench/api/common/extHost.protocol.ts b/src/vs/workbench/api/common/extHost.protocol.ts
-index eb5d8ea845..da9eb521ca 100644
+index eb5d8ea8455..da9eb521ca4 100644
 --- a/src/vs/workbench/api/common/extHost.protocol.ts
 +++ b/src/vs/workbench/api/common/extHost.protocol.ts
 @@ -769,6 +769,16 @@ export interface MainThreadLabelServiceShape extends IDisposable {
@@ -2876,7 +2877,7 @@ index eb5d8ea845..da9eb521ca 100644
  	ExtHostTunnelService: createMainId<ExtHostTunnelServiceShape>('ExtHostTunnelService'),
  	ExtHostAuthentication: createMainId<ExtHostAuthenticationShape>('ExtHostAuthentication'),
 diff --git a/src/vs/workbench/api/common/extHostExtensionService.ts b/src/vs/workbench/api/common/extHostExtensionService.ts
-index 34639e18b6..9c22fe6f09 100644
+index 34639e18b6f..9c22fe6f090 100644
 --- a/src/vs/workbench/api/common/extHostExtensionService.ts
 +++ b/src/vs/workbench/api/common/extHostExtensionService.ts
 @@ -32,6 +32,7 @@ import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitData
@@ -2930,7 +2931,7 @@ index 34639e18b6..9c22fe6f09 100644
  }
  
 diff --git a/src/vs/workbench/api/node/extHost.node.services.ts b/src/vs/workbench/api/node/extHost.node.services.ts
-index b3c89e51cf..e21abe4e13 100644
+index b3c89e51cfc..e21abe4e13b 100644
 --- a/src/vs/workbench/api/node/extHost.node.services.ts
 +++ b/src/vs/workbench/api/node/extHost.node.services.ts
 @@ -3,6 +3,8 @@
@@ -2948,7 +2949,7 @@ index b3c89e51cf..e21abe4e13 100644
  registerSingleton(IExtHostTunnelService, ExtHostTunnelService);
 +registerSingleton(IExtHostNodeProxy, class extends NotImplementedProxy<IExtHostNodeProxy>(String(IExtHostNodeProxy)) { whenReady = Promise.resolve(); });
 diff --git a/src/vs/workbench/api/worker/extHost.worker.services.ts b/src/vs/workbench/api/worker/extHost.worker.services.ts
-index 3843fdec38..8aac4df527 100644
+index 3843fdec386..8aac4df5278 100644
 --- a/src/vs/workbench/api/worker/extHost.worker.services.ts
 +++ b/src/vs/workbench/api/worker/extHost.worker.services.ts
 @@ -8,6 +8,7 @@ import { ILogService } from 'vs/platform/log/common/log';
@@ -2965,7 +2966,7 @@ index 3843fdec38..8aac4df527 100644
  registerSingleton(ILogService, ExtHostLogService);
 +registerSingleton(IExtHostNodeProxy, ExtHostNodeProxy);
 diff --git a/src/vs/workbench/api/worker/extHostExtensionService.ts b/src/vs/workbench/api/worker/extHostExtensionService.ts
-index c71ab1c7da..572b07ff25 100644
+index c71ab1c7da4..572b07ff251 100644
 --- a/src/vs/workbench/api/worker/extHostExtensionService.ts
 +++ b/src/vs/workbench/api/worker/extHostExtensionService.ts
 @@ -9,6 +9,7 @@ import { AbstractExtHostExtensionService } from 'vs/workbench/api/common/extHost
@@ -2995,7 +2996,7 @@ index c71ab1c7da..572b07ff25 100644
  		module = module.with({ path: ensureSuffix(module.path, '.js') });
  		const response = await fetch(module.toString(true));
 diff --git a/src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css b/src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css
-index ced2d81583..dfcae73e8a 100644
+index ced2d815834..dfcae73e8a0 100644
 --- a/src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css
 +++ b/src/vs/workbench/browser/parts/activitybar/media/activitybarpart.css
 @@ -55,6 +55,10 @@
@@ -3010,7 +3011,7 @@ index ced2d81583..dfcae73e8a 100644
  
  .monaco-workbench .activitybar > .content > .home-bar > .home-bar-icon-badge {
 diff --git a/src/vs/workbench/browser/web.main.ts b/src/vs/workbench/browser/web.main.ts
-index 0462617196..11434d27af 100644
+index 0462617196b..11434d27af9 100644
 --- a/src/vs/workbench/browser/web.main.ts
 +++ b/src/vs/workbench/browser/web.main.ts
 @@ -45,6 +45,7 @@ import { FileLogService } from 'vs/platform/log/common/fileLogService';
@@ -3031,7 +3032,7 @@ index 0462617196..11434d27af 100644
  		return instantiationService.invokeFunction(accessor => {
  			const commandService = accessor.get(ICommandService);
 diff --git a/src/vs/workbench/common/resources.ts b/src/vs/workbench/common/resources.ts
-index 18ea0bfedb..d59a17c17f 100644
+index 18ea0bfedb4..d59a17c17f4 100644
 --- a/src/vs/workbench/common/resources.ts
 +++ b/src/vs/workbench/common/resources.ts
 @@ -15,6 +15,7 @@ import { ParsedExpression, IExpression, parse } from 'vs/base/common/glob';
@@ -3053,7 +3054,7 @@ index 18ea0bfedb..d59a17c17f 100644
  				this._langIdKey.set(value ? this._modeService.getModeIdByFilepathOrFirstLine(value) : null);
  				this._extensionKey.set(value ? extname(value) : null);
 diff --git a/src/vs/workbench/contrib/scm/browser/media/scm.css b/src/vs/workbench/contrib/scm/browser/media/scm.css
-index 9947f240bf..bdba0a2fc6 100644
+index 9947f240bf2..bdba0a2fc64 100644
 --- a/src/vs/workbench/contrib/scm/browser/media/scm.css
 +++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
 @@ -138,9 +138,11 @@
@@ -3072,7 +3073,7 @@ index 9947f240bf..bdba0a2fc6 100644
  .scm-view .monaco-list .monaco-list-row .resource-group > .actions,
  .scm-view .monaco-list .monaco-list-row .resource > .name > .monaco-icon-label > .actions {
 diff --git a/src/vs/workbench/services/dialogs/browser/dialogService.ts b/src/vs/workbench/services/dialogs/browser/dialogService.ts
-index 6e3182a696..7df85da165 100644
+index 6e3182a696d..7df85da165a 100644
 --- a/src/vs/workbench/services/dialogs/browser/dialogService.ts
 +++ b/src/vs/workbench/services/dialogs/browser/dialogService.ts
 @@ -124,11 +124,12 @@ export class DialogService implements IDialogService {
@@ -3091,7 +3092,7 @@ index 6e3182a696..7df85da165 100644
  		};
  
 diff --git a/src/vs/workbench/services/environment/browser/environmentService.ts b/src/vs/workbench/services/environment/browser/environmentService.ts
-index ba2701ec54..4d4aaa6958 100644
+index ba2701ec54d..4d4aaa6958b 100644
 --- a/src/vs/workbench/services/environment/browser/environmentService.ts
 +++ b/src/vs/workbench/services/environment/browser/environmentService.ts
 @@ -121,8 +121,18 @@ export class BrowserWorkbenchEnvironmentService implements IWorkbenchEnvironment
@@ -3129,7 +3130,7 @@ index ba2701ec54..4d4aaa6958 100644
  				}
  			}
 diff --git a/src/vs/workbench/services/extensionManagement/common/extensionEnablementService.ts b/src/vs/workbench/services/extensionManagement/common/extensionEnablementService.ts
-index c28b147740..6090200d9c 100644
+index c28b1477400..6090200d9c3 100644
 --- a/src/vs/workbench/services/extensionManagement/common/extensionEnablementService.ts
 +++ b/src/vs/workbench/services/extensionManagement/common/extensionEnablementService.ts
 @@ -163,7 +163,7 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
@@ -3142,7 +3143,7 @@ index c28b147740..6090200d9c 100644
  		return false;
  	}
 diff --git a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
-index 33eb56db3c..e5167794c3 100644
+index 33eb56db3c2..e5167794c3f 100644
 --- a/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
 +++ b/src/vs/workbench/services/extensionManagement/common/extensionManagementService.ts
 @@ -236,6 +236,11 @@ export class ExtensionManagementService extends Disposable implements IExtension
@@ -3158,7 +3159,7 @@ index 33eb56db3c..e5167794c3 100644
  			const error = new Error(localize('cannot be installed', "Cannot install '{0}' because this extension has defined that it cannot run on the remote server.", gallery.displayName || gallery.name));
  			error.name = INSTALL_ERROR_NOT_SUPPORTED;
 diff --git a/src/vs/workbench/services/extensions/browser/extensionService.ts b/src/vs/workbench/services/extensions/browser/extensionService.ts
-index d0710e77fa..ceb27174ae 100644
+index d0710e77fa2..ceb27174aee 100644
 --- a/src/vs/workbench/services/extensions/browser/extensionService.ts
 +++ b/src/vs/workbench/services/extensions/browser/extensionService.ts
 @@ -116,8 +116,10 @@ export class ExtensionService extends AbstractExtensionService implements IExten
@@ -3174,7 +3175,7 @@ index d0710e77fa..ceb27174ae 100644
  		const remoteAgentConnection = this._remoteAgentService.getConnection();
  		this._runningLocation = _determineRunningLocation(this._productService, this._configService, localExtensions, remoteExtensions, Boolean(remoteEnv && remoteAgentConnection));
 diff --git a/src/vs/workbench/services/extensions/common/extensionsUtil.ts b/src/vs/workbench/services/extensions/common/extensionsUtil.ts
-index 65e532ee58..0b6282fde7 100644
+index 65e532ee58d..0b6282fde7a 100644
 --- a/src/vs/workbench/services/extensions/common/extensionsUtil.ts
 +++ b/src/vs/workbench/services/extensions/common/extensionsUtil.ts
 @@ -37,7 +37,8 @@ export function canExecuteOnWorkspace(manifest: IExtensionManifest, productServi
@@ -3188,7 +3189,7 @@ index 65e532ee58..0b6282fde7 100644
  
  export function getExtensionKind(manifest: IExtensionManifest, productService: IProductService, configurationService: IConfigurationService): ExtensionKind[] {
 diff --git a/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts b/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
-index 49542eda74..de0e2da0a4 100644
+index 49542eda74c..de0e2da0a4c 100644
 --- a/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
 +++ b/src/vs/workbench/services/extensions/node/extensionHostProcessSetup.ts
 @@ -16,7 +16,7 @@ import { IInitData } from 'vs/workbench/api/common/extHost.protocol';
@@ -3245,7 +3246,7 @@ index 49542eda74..de0e2da0a4 100644
  			console.error(e);
  		}
 diff --git a/src/vs/workbench/services/extensions/worker/extensionHostWorkerMain.ts b/src/vs/workbench/services/extensions/worker/extensionHostWorkerMain.ts
-index 79455414c0..a407593b4d 100644
+index 79455414c06..a407593b4dc 100644
 --- a/src/vs/workbench/services/extensions/worker/extensionHostWorkerMain.ts
 +++ b/src/vs/workbench/services/extensions/worker/extensionHostWorkerMain.ts
 @@ -14,7 +14,11 @@
@@ -3262,7 +3263,7 @@ index 79455414c0..a407593b4d 100644
  
  	require(['vs/workbench/services/extensions/worker/extensionHostWorker'], () => { }, err => console.error(err));
 diff --git a/src/vs/workbench/services/localizations/electron-browser/localizationsService.ts b/src/vs/workbench/services/localizations/electron-browser/localizationsService.ts
-index 44999bd842..601b1c5408 100644
+index 44999bd842e..601b1c54088 100644
 --- a/src/vs/workbench/services/localizations/electron-browser/localizationsService.ts
 +++ b/src/vs/workbench/services/localizations/electron-browser/localizationsService.ts
 @@ -5,17 +5,17 @@
@@ -3287,7 +3288,7 @@ index 44999bd842..601b1c5408 100644
  }
  
 diff --git a/src/vs/workbench/workbench.web.main.ts b/src/vs/workbench/workbench.web.main.ts
-index 0669178db4..28fafeb2de 100644
+index 0669178db4c..28fafeb2de2 100644
 --- a/src/vs/workbench/workbench.web.main.ts
 +++ b/src/vs/workbench/workbench.web.main.ts
 @@ -35,7 +35,8 @@ import 'vs/workbench/services/textfile/browser/browserTextFileService';
@@ -3301,7 +3302,7 @@ index 0669178db4..28fafeb2de 100644
  import 'vs/workbench/services/credentials/browser/credentialsService';
  import 'vs/workbench/services/url/browser/urlService';
 diff --git a/yarn.lock b/yarn.lock
-index b2fbf543af..f10dddd659 100644
+index b2fbf543af3..f10dddd6594 100644
 --- a/yarn.lock
 +++ b/yarn.lock
 @@ -140,6 +140,23 @@

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -45,6 +45,9 @@ export interface Args extends VsArgs {
   readonly "proxy-domain"?: string[]
   readonly locale?: string
   readonly _: string[]
+  readonly "open-in"?: boolean
+  readonly "reuse-window"?: boolean
+  readonly "new-window"?: boolean
 }
 
 interface Option<T> {
@@ -138,6 +141,18 @@ const options: Options<Required<Args>> = {
   "uninstall-extension": { type: "string[]", description: "Uninstall a VS Code extension by id." },
   "show-versions": { type: "boolean", description: "Show VS Code extension versions." },
   "proxy-domain": { type: "string[]", description: "Domain used for proxying ports." },
+
+  "open-in": { type: "boolean", short: "oi", description: "Open file(s) or folder(s) in running instance" },
+  "new-window": {
+    type: "boolean",
+    short: "n",
+    description: "Force to open a new window. (use with open-in)",
+  },
+  "reuse-window": {
+    type: "boolean",
+    short: "r",
+    description: "Force to open a file or folder in an already opened window. (use with open-in)",
+  },
 
   locale: { type: "string" },
   log: { type: LogLevel },

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -64,9 +64,9 @@ const main = async (args: Args, cliArgs: Args, configArgs: Args): Promise<void> 
     ...(args.cert && !args.cert.value
       ? await generateCertificate()
       : {
-        cert: args.cert && args.cert.value,
-        certKey: args["cert-key"],
-      }),
+          cert: args.cert && args.cert.value,
+          certKey: args["cert-key"],
+        }),
   }
 
   if (options.cert && !options.certKey) {


### PR DESCRIPTION
Add initial support for opening files / folders in running code-server instance.

Capabilities:

- Open an existing/new file(s) in running instance
```shell
$ code-server --reuse-window --open-in foo.txt
# or
$ code-server -oi foo.txt -r
```
- Open an existing folder in a new window
```shell
$ code-server --new-window --open-in path/to/project
# or
$ code-server -oi path/to/project -n
```

Current limitations:

- unable to open a file in a new window, only folders
- unable to use addMode feature
- others...

#164 
