### PR TITLE
Remove custom offline text

### DIFF
--- a/src/browser/serviceWorker.ts
+++ b/src/browser/serviceWorker.ts
@@ -8,17 +8,6 @@ self.addEventListener("activate", (event: any) => {
   event.waitUntil((self as any).clients.claim())
 })
 
-self.addEventListener("fetch", (event: any) => {
-  if (!navigator.onLine) {
-    event.respondWith(
-      new Promise((resolve) => {
-        resolve(
-          new Response("OFFLINE", {
-            status: 200,
-            statusText: "OK",
-          }),
-        )
-      }),
-    )
-  }
+self.addEventListener("fetch", () => {
+  // Without this event handler we won't be recognized as a PWA.
 })


### PR DESCRIPTION
We need the handler to be recognized as a PWA but we can just let the
original offline browser message show instead of our own message.

See #1925 and #1979.
