### PR TITLE
Remove open-in flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "./ci/dev/lint.sh",
     "test": "./ci/dev/test.sh",
     "ci": "./ci/dev/ci.sh",
-    "watch": "NODE_OPTIONS=--max_old_space_size=32384 ts-node ./ci/dev/watch.ts"
+    "watch": "VSCODE_IPC_HOOK_CLI= NODE_OPTIONS=--max_old_space_size=32384 ts-node ./ci/dev/watch.ts"
   },
   "main": "out/node/entry.js",
   "devDependencies": {

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -45,7 +45,6 @@ export interface Args extends VsArgs {
   readonly "proxy-domain"?: string[]
   readonly locale?: string
   readonly _: string[]
-  readonly "open-in"?: boolean
   readonly "reuse-window"?: boolean
   readonly "new-window"?: boolean
 }
@@ -142,7 +141,6 @@ const options: Options<Required<Args>> = {
   "show-versions": { type: "boolean", description: "Show VS Code extension versions." },
   "proxy-domain": { type: "string[]", description: "Domain used for proxying ports." },
 
-  "open-in": { type: "boolean", short: "oi", description: "Open file(s) or folder(s) in running instance" },
   "new-window": {
     type: "boolean",
     short: "n",
@@ -372,7 +370,7 @@ export async function readConfigFile(configPath?: string): Promise<Args> {
     logger.info(`Wrote default config file to ${humanPath(configPath)}`)
   }
 
-  if (!process.env.CODE_SERVER_PARENT_PID) {
+  if (!process.env.CODE_SERVER_PARENT_PID && !process.env.VSCODE_IPC_HOOK_CLI) {
     logger.info(`Using config file ${humanPath(configPath)}`)
   }
 

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -164,14 +164,13 @@ async function entry(): Promise<void> {
       console.log(version, commit)
     }
     process.exit(0)
-  } else if (args["open-in"]) {
-    if (!process.env["VSCODE_IPC_HOOK_CLI"]) {
-      logger.error("VSCODE_IPC_HOOK_CLI missing from environment, unable to run")
-      process.exit(1)
+  } else if (process.env.VSCODE_IPC_HOOK_CLI) {
+    const pipeArgs: OpenCommandPipeArgs = {
+      type: "open",
+      folderURIs: [],
+      forceReuseWindow: args["reuse-window"],
+      forceNewWindow: args["new-window"],
     }
-    const pipeArgs: OpenCommandPipeArgs = { type: "open", folderURIs: [] }
-    pipeArgs.forceReuseWindow = args["reuse-window"]
-    pipeArgs.forceNewWindow = args["new-window"]
     const isDir = async (path: string): Promise<boolean> => {
       try {
         const st = await fs.stat(path)
@@ -196,7 +195,7 @@ async function entry(): Promise<void> {
       process.exit(1)
     }
     if (pipeArgs.folderURIs.length === 0 && (!pipeArgs.fileURIs || pipeArgs.fileURIs.length === 0)) {
-      logger.error("open-in expects at least one file or folder argument")
+      logger.error("Please specify at least one file or folder argument")
       process.exit(1)
     }
     const vscode = http.request(


### PR DESCRIPTION
- Always launch into the existing instance if there is a socket
  - VS Code sets this variable when the socket is created so if this is set it should mean the socket exists
- Unset for `yarn watch` so you can still develop code-server inside code-server
  - Otherwise it would just send to the socket instead of launching
- Avoid the config info line when sending to an existing instance