### PR TITLE
Add variables to better customize plugin directories

### DIFF
--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -69,7 +69,7 @@ const _loadPlugins = async (pluginDir: string, httpServer: HttpServer, args: Arg
  * `CS_PLUGIN` (also colon-separated).
  */
 export const loadPlugins = async (httpServer: HttpServer, args: Args): Promise<void> => {
-  const pluginPath = process.env.CS_PLUGIN_PATH || `${path.join(paths.data, "plugins")}:/etc/code-server/plugins`
+  const pluginPath = process.env.CS_PLUGIN_PATH || `${path.join(paths.data, "plugins")}:/usr/share/code-server/plugins`
   const plugin = process.env.CS_PLUGIN || ""
   await Promise.all([
     // Built-in plugins.

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -41,11 +41,7 @@ const loadPlugin = async (pluginPath: string, httpServer: HttpServer, args: Args
       field("version", require(path.join(pluginPath, "package.json")).version || "n/a"),
     )
   } catch (error) {
-    if (error.code !== "MODULE_NOT_FOUND") {
-      logger.warn(error.message)
-    } else {
-      logger.error(error.message)
-    }
+    logger.error(error.message)
   }
 }
 

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -34,7 +34,12 @@ const loadPlugin = async (pluginPath: string, httpServer: HttpServer, args: Args
   try {
     const plugin: Plugin = require(pluginPath)
     plugin.activate(httpServer, args)
-    logger.debug("Loaded plugin", field("name", path.basename(pluginPath)))
+
+    logger.debug(
+      "Loaded plugin",
+      field("name", path.basename(pluginPath)),
+      field("version", require(path.join(pluginPath, "package.json")).version || "n/a"),
+    )
   } catch (error) {
     if (error.code !== "MODULE_NOT_FOUND") {
       logger.warn(error.message)

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -35,10 +35,12 @@ const loadPlugin = async (pluginPath: string, httpServer: HttpServer, args: Args
     const plugin: Plugin = require(pluginPath)
     plugin.activate(httpServer, args)
 
+    const packageJson = require(path.join(pluginPath, "package.json"))
     logger.debug(
       "Loaded plugin",
-      field("name", path.basename(pluginPath)),
-      field("version", require(path.join(pluginPath, "package.json")).version || "n/a"),
+      field("name", packageJson.name || path.basename(pluginPath)),
+      field("path", pluginPath),
+      field("version", packageJson.version || "n/a"),
     )
   } catch (error) {
     logger.error(error.message)


### PR DESCRIPTION
- Still loads all plugins from the `plugins` directory as before
  - But now `PLUGIN_DIR` will set that directory instead of being used to specify an individual plugin
  - This is the directory I envision being used for distributing code-server with plugins or where plugins would be placed for running instances of code-server in production by users
- `PLUGIN_DIRS` can be used to set multiple individual plugins if you don't want to move them into a single directory
  - Really only intended for development

Lemme know if we wanna change this up, this is just based off the VS Code plugin structure (except they use command line flags and not environment variables).

Closes #2122.