### PR TITLE
Allow building release without deleting existing node_modules

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 # MINIFY controls whether minified vscode is bundled.
 MINIFY="${MINIFY-true}"
 
+# KEEP_MODULES controls whether the script cleans all node_modules requiring a yarn install
+# to run first.
+KEEP_MODULES="${KEEP_MODULES-0}"
+
 main() {
   cd "$(dirname "${0}")/../.."
   source ./ci/lib.sh
@@ -52,6 +56,11 @@ EOF
   ) > "$RELEASE_PATH/package.json"
   rsync yarn.lock "$RELEASE_PATH"
   rsync ci/build/npm-postinstall.sh "$RELEASE_PATH/postinstall.sh"
+
+
+  if [ "$KEEP_MODULES" = 1 ]; then
+    rsync node_modules/ "$RELEASE_PATH/node_modules"
+  fi
 }
 
 bundle_vscode() {
@@ -60,7 +69,11 @@ bundle_vscode() {
   rsync "$VSCODE_SRC_PATH/out-vscode${MINIFY+-min}/" "$VSCODE_OUT_PATH/out"
 
   rsync "$VSCODE_SRC_PATH/.build/extensions/" "$VSCODE_OUT_PATH/extensions"
-  rm -Rf "$VSCODE_OUT_PATH/extensions/node_modules"
+  if [ "$KEEP_MODULES" = 0 ]; then
+    rm -Rf "$VSCODE_OUT_PATH/extensions/node_modules"
+  else
+    rsync "$VSCODE_SRC_PATH/node_modules/" "$VSCODE_OUT_PATH/node_modules"
+  fi
   rsync "$VSCODE_SRC_PATH/extensions/package.json" "$VSCODE_OUT_PATH/extensions"
   rsync "$VSCODE_SRC_PATH/extensions/yarn.lock" "$VSCODE_OUT_PATH/extensions"
   rsync "$VSCODE_SRC_PATH/extensions/postinstall.js" "$VSCODE_OUT_PATH/extensions"


### PR DESCRIPTION
```
KEEP_MODULES=1 ./ci/steps/release.sh && node ./release --auth=none
```

Can be ran to build & test a release quickly.