### PR TITLE
cloud: Rename --coder-bind to --link

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -48,7 +48,7 @@ export interface Args extends VsArgs {
   readonly "reuse-window"?: boolean
   readonly "new-window"?: boolean
 
-  readonly "coder-bind"?: OptionalString
+  readonly link?: OptionalString
 }
 
 interface Option<T> {
@@ -164,7 +164,7 @@ const options: Options<Required<Args>> = {
   log: { type: LogLevel },
   verbose: { type: "boolean", short: "vvv", description: "Enable verbose logging." },
 
-  "coder-bind": {
+  link: {
     type: OptionalString,
     description: `
       Securely bind code-server via Coder Cloud with the passed name. You'll get a URL like

--- a/src/node/coder-cloud.ts
+++ b/src/node/coder-cloud.ts
@@ -3,6 +3,7 @@ import { spawn } from "child_process"
 import path from "path"
 import split2 from "split2"
 
+// https://github.com/cdr/coder-cloud
 const coderCloudAgent = path.resolve(__dirname, "../../lib/coder-cloud-agent")
 
 function runAgent(...args: string[]): Promise<void> {

--- a/src/node/coder-cloud.ts
+++ b/src/node/coder-cloud.ts
@@ -33,7 +33,7 @@ function runAgent(...args: string[]): Promise<void> {
 }
 
 export function coderCloudBind(csAddr: string, serverName = ""): Promise<void> {
-  logger.info("Remember --coder-bind is a beta feature and requires being accepted for testing")
+  logger.info("Remember --link is a beta feature and requires being accepted for testing")
   logger.info("See https://github.com/cdr/code-server/discussions/2137")
   // addr needs to be in host:port format.
   // So we trim the protocol.

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -36,7 +36,7 @@ const version = pkg.version || "development"
 const commit = pkg.commit || "development"
 
 const main = async (args: Args, configArgs: Args): Promise<void> => {
-  if (args["coder-bind"]) {
+  if (args.link) {
     // If we're being exposed to the cloud, we listen on a random address and disable auth.
     args = {
       ...args,
@@ -46,7 +46,7 @@ const main = async (args: Args, configArgs: Args): Promise<void> => {
       socket: undefined,
       cert: undefined,
     }
-    logger.info("coder-bind: disabling auth and listening on random localhost port")
+    logger.info("link: disabling auth and listening on random localhost port for cloud agent")
   }
 
   if (!args.auth) {
@@ -143,9 +143,9 @@ const main = async (args: Args, configArgs: Args): Promise<void> => {
     logger.info(`Opened ${openAddress}`)
   }
 
-  if (args["coder-bind"]) {
+  if (args.link) {
     try {
-      await coderCloudBind(serverAddress!, args["coder-bind"].value)
+      await coderCloudBind(serverAddress!, args.link.value)
     } catch (err) {
       logger.error(err.message)
       ipcMain().exit(1)


### PR DESCRIPTION
As discussed, the team believes `--link` to be more succinct while still expressive.