### PR TITLE
Fix a styling issue on iOS/iPadOs

### DIFF
--- a/src/browser/pages/login.css
+++ b/src/browser/pages/login.css
@@ -26,7 +26,7 @@ body {
   border: 1px solid #ddd;
   box-sizing: border-box;
   color: black;
-  flex: 1;
+  width: 100%;
   padding: 16px;
 }
 
@@ -34,6 +34,16 @@ body {
   display: none;
 }
 
-.login-form > .field > .submit {
+.login-form > .field > input[type="submit"] {
+  position: absolute;
+  left: -9999px;
+}
+
+.login-form > .field > input[type="submit"]:focus + label {
+  border: 2px solid #000;
+}
+
+.login-form > .field > .submit{
   margin-left: 20px;
+  flex-shrink: 0;
 }

--- a/src/browser/pages/login.html
+++ b/src/browser/pages/login.html
@@ -38,7 +38,8 @@
                 name="password"
                 autocomplete="current-password"
               />
-              <input class="submit -button" value="SUBMIT" type="submit" />
+	            <input value="SUBMIT" type="submit" id="submit-button">
+	            <label for="submit-button" class="submit -button">SUBMIT</label>
             </div>
             {{ERROR}}
           </form>


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the master branch!
-->

Related issue: [https://github.com/cdr/code-server/issues/2247](https://github.com/cdr/code-server/issues/2247)

So, instead of using button elements( including `input[type="submit"]`)  directly on page, I added a `label` element which preserved the style while remaining the same functionality.

### Before
![image](https://user-images.githubusercontent.com/29943110/97517587-76165880-19d0-11eb-942a-4a9517601b3b.png)


### After 
![image](https://user-images.githubusercontent.com/29943110/97517610-7dd5fd00-19d0-11eb-8ed1-6495c96ae2f2.png)

Over all, not a big problem but still, an improvement.