### PR TITLE
add Slack link to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,6 @@ contact_links:
   - name: Question
     url: https://github.com/cdr/code-server/discussions/new?category_id=22503114
     about: Ask the community for help on our GitHub Discussions board
-  - name: Need immediate help or just want to talk?
-    about: Hop in our Slack and talk to the code-server engineers and community
+  - name: Chat
+    about: Need immediate help or just want to talk? Hop in our Slack
     url: https://cdr.co/join-community

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Question
     url: https://github.com/cdr/code-server/discussions/new?category_id=22503114
-    about: Ask the community for help
+    about: Ask the community for help on our GitHub Discussions board
+  - name: Need immediate help or just want to talk?
+    about: Hop in our Slack and talk to the code-server engineers and community
+    url: https://cdr.co/join-community


### PR DESCRIPTION
adds Slack link to GitHub issues template, as suggested by @wbobeirne 