### PR TITLE
v3.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We also have an in-depth [setup and configuration](./doc/guide.md) guide.
 
 ### Alpha Program 🐣
 
-We're working on a cloud platform that makes deploying and managing code-server easier. Consider [updating to 3.6.2](https://github.com/cdr/code-server/releases/tag/v3.6.2) and running code-server with our experimental flag `--link` if you don't want to worry about
+We're working on a cloud platform that makes deploying and managing code-server easier. Consider [updating to 3.7.0](https://github.com/cdr/code-server/releases/tag/v3.7.0) and running code-server with our experimental flag `--link` if you don't want to worry about
 
 - TLS
 - Authentication

--- a/ci/README.md
+++ b/ci/README.md
@@ -17,6 +17,7 @@ Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) 
 1. Update the version of code-server and make a PR.
    1. Update in `package.json`
    2. Update in [./doc/install.md](../doc/install.md)
+   3. Update in [./ci/helm-chart/README.md](../ci/helm-chart/README.md)
 2. GitHub actions will generate the `npm-package`, `release-packages` and `release-images` artifacts.
    1. You do not have to wait for these.
 3. Run `yarn release:github-draft` to create a GitHub draft release from the template with

--- a/ci/build/test-standalone-release.sh
+++ b/ci/build/test-standalone-release.sh
@@ -15,7 +15,8 @@ main() {
   ./release-standalone/bin/code-server --extensions-dir "$EXTENSIONS_DIR" --install-extension ms-python.python
   local installed_extensions
   installed_extensions="$(./release-standalone/bin/code-server --extensions-dir "$EXTENSIONS_DIR" --list-extensions 2>&1)"
-  if [[ $installed_extensions != "ms-python.python" ]]; then
+  # We use grep as ms-python.python may have dependency extensions that change.
+  if ! echo "$installed_extensions" | grep -q "ms-python.python"; then
     echo "Unexpected output from listing extensions:"
     echo "$installed_extensions"
     exit 1

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.0.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.6.2
+appVersion: 3.7.0

--- a/ci/helm-chart/README.md
+++ b/ci/helm-chart/README.md
@@ -1,6 +1,6 @@
 # code-server
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.6.2](https://img.shields.io/badge/AppVersion-3.6.2-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.7.0](https://img.shields.io/badge/AppVersion-3.7.0-informational?style=flat-square)
 
 [code-server](https://github.com/cdr/code-server) code-server is VS Code running
 on a remote server, accessible through the browser.
@@ -72,7 +72,7 @@ and their default values.
 | hostnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"codercom/code-server"` |  |
-| image.tag | string | `"3.5.0"` |  |
+| image.tag | string | `"3.7.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '3.6.2'
+  tag: '3.7.0'
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/doc/install.md
+++ b/doc/install.md
@@ -80,8 +80,8 @@ commands presented in the rest of this document.
 ## Debian, Ubuntu
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.6.1/code-server_3.6.1_amd64.deb
-sudo dpkg -i code-server_3.6.1_amd64.deb
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.7.0/code-server_3.7.0_amd64.deb
+sudo dpkg -i code-server_3.7.0_amd64.deb
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -89,8 +89,8 @@ sudo systemctl enable --now code-server@$USER
 ## Fedora, CentOS, RHEL, SUSE
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.6.1/code-server-3.6.1-amd64.rpm
-sudo rpm -i code-server-3.6.1-amd64.rpm
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.7.0/code-server-3.7.0-amd64.rpm
+sudo rpm -i code-server-3.7.0-amd64.rpm
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -159,10 +159,10 @@ Here is an example script for installing and using a standalone `code-server` re
 
 ```bash
 mkdir -p ~/.local/lib ~/.local/bin
-curl -fL https://github.com/cdr/code-server/releases/download/v3.6.1/code-server-3.6.1-linux-amd64.tar.gz \
+curl -fL https://github.com/cdr/code-server/releases/download/v3.7.0/code-server-3.7.0-linux-amd64.tar.gz \
   | tar -C ~/.local/lib -xz
-mv ~/.local/lib/code-server-3.6.1-linux-amd64 ~/.local/lib/code-server-3.6.1
-ln -s ~/.local/lib/code-server-3.6.1/bin/code-server ~/.local/bin/code-server
+mv ~/.local/lib/code-server-3.7.0-linux-amd64 ~/.local/lib/code-server-3.7.0
+ln -s ~/.local/lib/code-server-3.7.0/bin/code-server ~/.local/bin/code-server
 PATH="~/.local/bin:$PATH"
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/cdr/code-server",
   "bugs": {

--- a/src/node/plugin.ts
+++ b/src/node/plugin.ts
@@ -185,7 +185,7 @@ export class PluginAPI {
     if (!packageJSON.engines || !packageJSON.engines["code-server"]) {
       throw new Error(`plugin package.json missing code-server range like:
   "engines": {
-    "code-server": "^3.6.0"
+    "code-server": "^3.7.0"
    }
 `)
     }

--- a/test/test-plugin/package.json
+++ b/test/test-plugin/package.json
@@ -3,7 +3,7 @@
   "name": "test-plugin",
   "version": "1.0.0",
   "engines": {
-    "code-server": "^3.6.0"
+    "code-server": "^3.7.0"
   },
   "main": "out/index.js",
   "devDependencies": {


### PR DESCRIPTION
VS Code v1.50.0

## Features

- ⭐ code-server is now written with Express! This will make the codebase far more approachable for contributors #1899 
  - Previously we were using node's HTTP API directly
- ⭐ We now have a helm chart! Thank you @Matthew-Beckett @alexgorbatchev! #2048 
  - See [ci/helm-chart](https://github.com/cdr/code-server/tree/v3.7.0/ci/helm-chart)
- ⭐ code-server's self signed certificates now work on iPad! See [doc/ipad.md](https://github.com/cdr/code-server/blob/v3.7.0/doc/ipad.md) #2255 

## Bug Fixes

- code-server's self signed certificates now go into the data directory #1778
- The path and domain proxy now only redirects unauthenticated clients to login if they accept HTML #2128 