### PR TITLE
Separate process wrappers and pass arguments

### DIFF
--- a/src/node/vscode.ts
+++ b/src/node/vscode.ts
@@ -8,7 +8,7 @@ import { rootPath } from "./constants"
 import { settings } from "./settings"
 import { SocketProxyProvider } from "./socket"
 import { isFile } from "./util"
-import { ipcMain } from "./wrapper"
+import { wrapper } from "./wrapper"
 
 export class VscodeProvider {
   public readonly serverRootPath: string
@@ -20,7 +20,7 @@ export class VscodeProvider {
   public constructor() {
     this.vsRootPath = path.resolve(rootPath, "lib/vscode")
     this.serverRootPath = path.join(this.vsRootPath, "out/vs/server")
-    ipcMain.onDispose(() => this.dispose())
+    wrapper.onDispose(() => this.dispose())
   }
 
   public async dispose(): Promise<void> {

--- a/src/node/vscode.ts
+++ b/src/node/vscode.ts
@@ -1,4 +1,4 @@
-import { field, logger } from "@coder/logger"
+import { logger } from "@coder/logger"
 import * as cp from "child_process"
 import * as net from "net"
 import * as path from "path"
@@ -8,13 +8,12 @@ import { rootPath } from "./constants"
 import { settings } from "./settings"
 import { SocketProxyProvider } from "./socket"
 import { isFile } from "./util"
-import { wrapper } from "./wrapper"
+import { onMessage, wrapper } from "./wrapper"
 
 export class VscodeProvider {
   public readonly serverRootPath: string
   public readonly vsRootPath: string
   private _vscode?: Promise<cp.ChildProcess>
-  private timeoutInterval = 10000 // 10s, matches VS Code's timeouts.
   private readonly socketProvider = new SocketProxyProvider()
 
   public constructor() {
@@ -69,10 +68,13 @@ export class VscodeProvider {
       vscode,
     )
 
-    const message = await this.onMessage(vscode, (message): message is ipc.OptionsMessage => {
-      // There can be parallel initializations so wait for the right ID.
-      return message.type === "options" && message.id === id
-    })
+    const message = await onMessage<ipc.VscodeMessage, ipc.OptionsMessage>(
+      vscode,
+      (message): message is ipc.OptionsMessage => {
+        // There can be parallel initializations so wait for the right ID.
+        return message.type === "options" && message.id === id
+      },
+    )
 
     return message.options
   }
@@ -104,59 +106,11 @@ export class VscodeProvider {
       dispose()
     })
 
-    this._vscode = this.onMessage(vscode, (message): message is ipc.ReadyMessage => {
+    this._vscode = onMessage<ipc.VscodeMessage, ipc.ReadyMessage>(vscode, (message): message is ipc.ReadyMessage => {
       return message.type === "ready"
     }).then(() => vscode)
 
     return this._vscode
-  }
-
-  /**
-   * Listen to a single message from a process. Reject if the process errors,
-   * exits, or times out.
-   *
-   * `fn` is a function that determines whether the message is the one we're
-   * waiting for.
-   */
-  private onMessage<T extends ipc.VscodeMessage>(
-    proc: cp.ChildProcess,
-    fn: (message: ipc.VscodeMessage) => message is T,
-  ): Promise<T> {
-    return new Promise((resolve, reject) => {
-      const cleanup = () => {
-        proc.off("error", onError)
-        proc.off("exit", onExit)
-        proc.off("message", onMessage)
-        clearTimeout(timeout)
-      }
-
-      const timeout = setTimeout(() => {
-        cleanup()
-        reject(new Error("timed out"))
-      }, this.timeoutInterval)
-
-      const onError = (error: Error) => {
-        cleanup()
-        reject(error)
-      }
-
-      const onExit = (code: number | null) => {
-        cleanup()
-        reject(new Error(`VS Code exited unexpectedly with code ${code}`))
-      }
-
-      const onMessage = (message: ipc.VscodeMessage) => {
-        logger.trace("got message from vscode", field("message", message))
-        if (fn(message)) {
-          cleanup()
-          resolve(message)
-        }
-      }
-
-      proc.on("message", onMessage)
-      proc.on("error", onError)
-      proc.on("exit", onExit)
-    })
   }
 
   /**

--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -1,4 +1,4 @@
-import { field, logger } from "@coder/logger"
+import { Logger, field, logger } from "@coder/logger"
 import * as cp from "child_process"
 import * as path from "path"
 import * as rfs from "rotating-file-stream"
@@ -14,9 +14,9 @@ interface RelaunchMessage {
   version: string
 }
 
-export type Message = RelaunchMessage | HandshakeMessage
+type Message = RelaunchMessage | HandshakeMessage
 
-export class ProcessError extends Error {
+class ProcessError extends Error {
   public constructor(message: string, public readonly code: number | undefined) {
     super(message)
     this.name = this.constructor.name
@@ -25,16 +25,26 @@ export class ProcessError extends Error {
 }
 
 /**
- * Allows the wrapper and inner processes to communicate.
+ * Wrapper around a process that tries to gracefully exit when a process exits
+ * and provides a way to prevent `process.exit`.
  */
-export class IpcMain {
-  private readonly _onMessage = new Emitter<Message>()
-  public readonly onMessage = this._onMessage.event
-  private readonly _onDispose = new Emitter<NodeJS.Signals | undefined>()
-  public readonly onDispose = this._onDispose.event
-  public readonly processExit: (code?: number) => never = process.exit
+abstract class Process {
+  /**
+   * Emit this to trigger a graceful exit.
+   */
+  protected readonly _onDispose = new Emitter<NodeJS.Signals | undefined>()
 
-  public constructor(private readonly parentPid?: number) {
+  /**
+   * Emitted when the process is about to be disposed.
+   */
+  public readonly onDispose = this._onDispose.event
+
+  /**
+   * Uniquely named logger for the process.
+   */
+  public abstract logger: Logger
+
+  public constructor() {
     process.on("SIGINT", () => this._onDispose.emit("SIGINT"))
     process.on("SIGTERM", () => this._onDispose.emit("SIGTERM"))
     process.on("exit", () => this._onDispose.emit(undefined))
@@ -43,42 +53,27 @@ export class IpcMain {
       // Remove listeners to avoid possibly triggering disposal again.
       process.removeAllListeners()
 
-      // Try waiting for other handlers run first then exit.
-      logger.debug(`${parentPid ? "inner process" : "wrapper"} ${process.pid} disposing`, field("code", signal))
+      // Try waiting for other handlers to run first then exit.
+      this.logger.debug("disposing", field("code", signal))
       wait.then(() => this.exit(0))
       setTimeout(() => this.exit(0), 5000)
     })
-
-    // Kill the inner process if the parent dies. This is for the case where the
-    // parent process is forcefully terminated and cannot clean up.
-    if (parentPid) {
-      setInterval(() => {
-        try {
-          // process.kill throws an exception if the process doesn't exist.
-          process.kill(parentPid, 0)
-        } catch (_) {
-          // Consider this an error since it should have been able to clean up
-          // the child process unless it was forcefully killed.
-          logger.error(`parent process ${parentPid} died`)
-          this._onDispose.emit(undefined)
-        }
-      }, 5000)
-    }
   }
 
   /**
-   * Ensure we control when the process exits.
+   * Ensure control over when the process exits.
    */
   public preventExit(): void {
-    process.exit = function (code?: number) {
-      logger.warn(`process.exit() was prevented: ${code || "unknown code"}.`)
-    } as (code?: number) => never
+    ;(process.exit as any) = (code?: number) => {
+      this.logger.warn(`process.exit() was prevented: ${code || "unknown code"}.`)
+    }
   }
 
-  public get isChild(): boolean {
-    return typeof this.parentPid !== "undefined"
-  }
+  private readonly processExit: (code?: number) => never = process.exit
 
+  /**
+   * Will always exit even if normal exit is being prevented.
+   */
   public exit(error?: number | ProcessError): never {
     if (error && typeof error !== "number") {
       this.processExit(typeof error.code === "number" ? error.code : 1)
@@ -86,47 +81,61 @@ export class IpcMain {
       this.processExit(error)
     }
   }
+}
 
-  public handshake(child?: cp.ChildProcess): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const target = child || process
+/**
+ * Child process that will clean up after itself if the parent goes away and can
+ * perform a handshake with the parent and ask it to relaunch.
+ */
+class ChildProcess extends Process {
+  public logger = logger.named(`child:${process.pid}`)
+
+  public constructor(private readonly parentPid: number) {
+    super()
+
+    // Kill the inner process if the parent dies. This is for the case where the
+    // parent process is forcefully terminated and cannot clean up.
+    setInterval(() => {
+      try {
+        // process.kill throws an exception if the process doesn't exist.
+        process.kill(this.parentPid, 0)
+      } catch (_) {
+        // Consider this an error since it should have been able to clean up
+        // the child process unless it was forcefully killed.
+        this.logger.error(`parent process ${parentPid} died`)
+        this._onDispose.emit(undefined)
+      }
+    }, 5000)
+  }
+
+  /**
+   * Initiate the handshake and wait for a response from the parent.
+   */
+  public handshake(): Promise<void> {
+    return new Promise((resolve) => {
       const onMessage = (message: Message): void => {
-        logger.debug(
-          `${child ? "wrapper" : "inner process"} ${process.pid} received message from ${
-            child ? child.pid : this.parentPid
-          }`,
-          field("message", message),
-        )
+        logger.debug(`received message from ${this.parentPid}`, field("message", message))
         if (message.type === "handshake") {
-          target.removeListener("message", onMessage)
-          target.on("message", (msg) => this._onMessage.emit(msg))
-          // The wrapper responds once the inner process starts the handshake.
-          if (child) {
-            if (!target.send) {
-              throw new Error("child not spawned with IPC")
-            }
-            target.send({ type: "handshake" })
-          }
+          process.removeListener("message", onMessage)
           resolve()
         }
       }
-      target.on("message", onMessage)
-      if (child) {
-        child.once("error", reject)
-        child.once("exit", (code) => {
-          reject(new ProcessError(`Unexpected exit with code ${code}`, code !== null ? code : undefined))
-        })
-      } else {
-        // The inner process initiates the handshake.
-        this.send({ type: "handshake" })
-      }
+      // Initiate the handshake and wait for the reply.
+      process.on("message", onMessage)
+      this.send({ type: "handshake" })
     })
   }
 
+  /**
+   * Notify the parent process that it should relaunch the child.
+   */
   public relaunch(version: string): void {
     this.send({ type: "relaunch", version })
   }
 
+  /**
+   * Send a message to the parent.
+   */
   private send(message: Message): void {
     if (!process.send) {
       throw new Error("not spawned with IPC")
@@ -135,29 +144,30 @@ export class IpcMain {
   }
 }
 
-/**
- * Channel for communication between the child and parent processes.
- */
-export const ipcMain = new IpcMain(
-  typeof process.env.CODE_SERVER_PARENT_PID !== "undefined" ? parseInt(process.env.CODE_SERVER_PARENT_PID) : undefined,
-)
-
 export interface WrapperOptions {
   maxMemory?: number
   nodeOptions?: string
 }
 
 /**
- * Provides a way to wrap a process for the purpose of updating the running
- * instance.
+ * Parent process wrapper that spawns the child process and performs a handshake
+ * with it. Will relaunch the child if it receives a SIGUSR1 or is asked to by
+ * the child. If the child otherwise exits the parent will also exit.
  */
-export class WrapperProcess {
-  private process?: cp.ChildProcess
+export class ParentProcess extends Process {
+  public logger = logger.named(`parent:${process.pid}`)
+
+  private child?: cp.ChildProcess
   private started?: Promise<void>
   private readonly logStdoutStream: rfs.RotatingFileStream
   private readonly logStderrStream: rfs.RotatingFileStream
 
+  protected readonly _onChildMessage = new Emitter<Message>()
+  protected readonly onChildMessage = this._onChildMessage.event
+
   public constructor(private currentVersion: string, private readonly options?: WrapperOptions) {
+    super()
+
     const opts = {
       size: "10M",
       maxFiles: 10,
@@ -165,19 +175,19 @@ export class WrapperProcess {
     this.logStdoutStream = rfs.createStream(path.join(paths.data, "coder-logs", "code-server-stdout.log"), opts)
     this.logStderrStream = rfs.createStream(path.join(paths.data, "coder-logs", "code-server-stderr.log"), opts)
 
-    ipcMain.onDispose(() => {
+    this.onDispose(() => {
       this.disposeChild()
     })
 
-    ipcMain.onMessage((message) => {
+    this.onChildMessage((message) => {
       switch (message.type) {
         case "relaunch":
-          logger.info(`Relaunching: ${this.currentVersion} -> ${message.version}`)
+          this.logger.info(`Relaunching: ${this.currentVersion} -> ${message.version}`)
           this.currentVersion = message.version
           this.relaunch()
           break
         default:
-          logger.error(`Unrecognized message ${message}`)
+          this.logger.error(`Unrecognized message ${message}`)
           break
       }
     })
@@ -185,9 +195,9 @@ export class WrapperProcess {
 
   private disposeChild(): void {
     this.started = undefined
-    if (this.process) {
-      this.process.removeAllListeners()
-      this.process.kill()
+    if (this.child) {
+      this.child.removeAllListeners()
+      this.child.kill()
     }
   }
 
@@ -196,16 +206,16 @@ export class WrapperProcess {
     try {
       await this.start()
     } catch (error) {
-      logger.error(error.message)
-      ipcMain.exit(typeof error.code === "number" ? error.code : 1)
+      this.logger.error(error.message)
+      this.exit(typeof error.code === "number" ? error.code : 1)
     }
   }
 
   public start(): Promise<void> {
     // If we have a process then we've already bound this.
-    if (!this.process) {
+    if (!this.child) {
       process.on("SIGUSR1", async () => {
-        logger.info("Received SIGUSR1; hotswapping")
+        this.logger.info("Received SIGUSR1; hotswapping")
         this.relaunch()
       })
     }
@@ -217,7 +227,7 @@ export class WrapperProcess {
 
   private async _start(): Promise<void> {
     const child = this.spawn()
-    this.process = child
+    this.child = child
 
     // Log both to stdout and to the log directory.
     if (child.stdout) {
@@ -229,13 +239,13 @@ export class WrapperProcess {
       child.stderr.pipe(process.stderr)
     }
 
-    logger.debug(`spawned inner process ${child.pid}`)
+    this.logger.debug(`spawned inner process ${child.pid}`)
 
-    await ipcMain.handshake(child)
+    await this.handshake(child)
 
     child.once("exit", (code) => {
-      logger.debug(`inner process ${child.pid} exited unexpectedly`)
-      ipcMain.exit(code || 0)
+      this.logger.debug(`inner process ${child.pid} exited unexpectedly`)
+      this.exit(code || 0)
     })
   }
 
@@ -256,18 +266,52 @@ export class WrapperProcess {
       stdio: ["ipc"],
     })
   }
+
+  /**
+   * Wait for a handshake from the child then reply.
+   */
+  private handshake(child: cp.ChildProcess): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const onMessage = (message: Message): void => {
+        logger.debug(`received message from ${child.pid}`, field("message", message))
+        if (message.type === "handshake") {
+          child.removeListener("message", onMessage)
+          child.on("message", (msg) => this._onChildMessage.emit(msg))
+          child.send({ type: "handshake" })
+          resolve()
+        }
+      }
+      child.on("message", onMessage)
+      child.once("error", reject)
+      child.once("exit", (code) => {
+        reject(new ProcessError(`Unexpected exit with code ${code}`, code !== null ? code : undefined))
+      })
+    })
+  }
+}
+
+/**
+ * Process wrapper.
+ */
+export const wrapper =
+  typeof process.env.CODE_SERVER_PARENT_PID !== "undefined"
+    ? new ChildProcess(parseInt(process.env.CODE_SERVER_PARENT_PID))
+    : new ParentProcess(require("../../package.json").version)
+
+export function isChild(proc: ChildProcess | ParentProcess): proc is ChildProcess {
+  return proc instanceof ChildProcess
 }
 
 // It's possible that the pipe has closed (for example if you run code-server
 // --version | head -1). Assume that means we're done.
 if (!process.stdout.isTTY) {
-  process.stdout.on("error", () => ipcMain.exit())
+  process.stdout.on("error", () => wrapper.exit())
 }
 
 // Don't let uncaught exceptions crash the process.
 process.on("uncaughtException", (error) => {
-  logger.error(`Uncaught exception: ${error.message}`)
+  wrapper.logger.error(`Uncaught exception: ${error.message}`)
   if (typeof error.stack !== "undefined") {
-    logger.error(error.stack)
+    wrapper.logger.error(error.stack)
   }
 })


### PR DESCRIPTION
This is to fix #2316.

Previously we only deleted `PASSWORD` in the child process but now it's deleted in the parent (which I think is good since that means it'll be hidden from the VS Code CLI spawn as well and anything else we might spawn from the parent in the future). 

But as a consequence the child no longer has access to `PASSWORD` and can't use it when parsing the arguments. This PR fixes that by passing the arguments from the parent to the child.

As a bonus this means we only have to do the parsing once, including if it gets restarted via a SIGUSR1.

Since it was getting a little convoluted with all the if statements I split out the child and parent process wrappers which I think makes it all a little more clear. Also was able to re-use `onMessage` from the VS Code wrapper.