### PR TITLE
Fix service worker not loading 

### DIFF
--- a/src/node/routes/static.ts
+++ b/src/node/routes/static.ts
@@ -52,6 +52,11 @@ router.get("/(:commit)(/*)?", async (req, res) => {
     res.header("Cache-Control", "public, max-age=31536000")
   }
 
+  // Without this the default is to use the directory the script loaded from.
+  if (req.headers["service-worker"]) {
+    res.header("service-worker-allowed", "/")
+  }
+
   res.set("Content-Type", getMediaMime(resourcePath))
 
   if (resourcePath.endsWith("manifest.json")) {


### PR DESCRIPTION
I removed this under the impression the default was to allow it anywhere
but that's not the case. Since the service worker was already registered
in my browser I never got the error during testing.