### PR TITLE
Add coder-log path to FAQ's 'How do I debug...' section

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -232,7 +232,7 @@ code-server --log debug
 Once this is done, replicate the issue you're having then collect logging
 information from the following places:
 
-1. stdout
+1. The most recent files from `~/.local/share/code-server/coder-logs`.
 2. The most recently created directory in the `~/.local/share/code-server/logs` directory.
 3. The browser console and network tabs.
 


### PR DESCRIPTION
Previously, the _How do I debub issues with code-server?_ section of FAQ was referencing `~/.local/share/code-server/logs`. For the more recent verions of code-server, it appears this log directory was renamed to `~/.local/share/code-server/coder-logs`