### PR TITLE
Remove the "install Xcode" bit

### DIFF
--- a/doc/npm.md
+++ b/doc/npm.md
@@ -36,9 +36,6 @@ npm config set python python2
 ```
 
 ## macOS
-
-Install [Xcode](https://developer.apple.com/xcode/downloads/) and run:
-
 ```bash
 xcode-select --install
 ```


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the master branch!
-->
I have not tested this myself, but I am pretty sure you don't need the full Xcode installed to build native node modules, just the command line tools. https://github.com/nodejs/node-gyp/blob/master/macOS_Catalina.md#solutions
