### PR TITLE
Add CodeTour

### DIFF
--- a/.tours/contributing.tour
+++ b/.tours/contributing.tour
@@ -50,7 +50,7 @@
     {
       "file": "src/node/heart.ts",
       "line": 7,
-      "description": "code-server's heart beats to indicate recent activity."
+      "description": "code-server's heart beats to indicate recent activity.\n\nAlso documented here: [https://github.com/cdr/code-server/blob/master/doc/FAQ.md#heartbeat-file](https://github.com/cdr/code-server/blob/master/doc/FAQ.md#heartbeat-file)"
     },
     {
       "file": "src/node/socket.ts",
@@ -80,12 +80,12 @@
     {
       "file": "src/node/routes/domainProxy.ts",
       "line": 18,
-      "description": "code-server provides a built-in proxy to help in developing web-based applications. This is the code for the domain-based proxy."
+      "description": "code-server provides a built-in proxy to help in developing web-based applications. This is the code for the domain-based proxy.\n\nAlso documented here: [https://github.com/cdr/code-server/blob/master/doc/FAQ.md#how-do-i-securely-access-web-services](https://github.com/cdr/code-server/blob/master/doc/FAQ.md#how-do-i-securely-access-web-services)"
     },
     {
       "file": "src/node/routes/pathProxy.ts",
       "line": 19,
-      "description": "Here is the path-based version of the proxy."
+      "description": "Here is the path-based version of the proxy.\n\nAlso documented here: [https://github.com/cdr/code-server/blob/master/doc/FAQ.md#how-do-i-securely-access-web-services](https://github.com/cdr/code-server/blob/master/doc/FAQ.md#how-do-i-securely-access-web-services)"
     },
     {
       "file": "src/node/proxy.ts",
@@ -95,7 +95,7 @@
     {
       "file": "src/node/routes/health.ts",
       "line": 5,
-      "description": "A simple endpoint that lets you see if code-server is up."
+      "description": "A simple endpoint that lets you see if code-server is up.\n\nAlso documented here: [https://github.com/cdr/code-server/blob/master/doc/FAQ.md#healthz-endpoint](https://github.com/cdr/code-server/blob/master/doc/FAQ.md#healthz-endpoint)"
     },
     {
       "file": "src/node/routes/login.ts",

--- a/.tours/contributing.tour
+++ b/.tours/contributing.tour
@@ -5,7 +5,7 @@
     {
       "directory": "src",
       "line": 1,
-      "description": "Hello world! code-server's source code lives here. It's broadly arranged into browser code, Node code, and code shared between both."
+      "description": "Hello world! code-server's source code lives here in `src` (see the explorer). It's broadly arranged into browser code, Node code, and code shared between both."
     },
     {
       "file": "src/node/entry.ts",
@@ -58,9 +58,9 @@
       "description": "We pass sockets to child processes, however we can't pass TLS sockets so when code-server is handling TLS (via --cert) we use this to create a proxy that can be passed to the child."
     },
     {
-      "file": "src/node/routes",
+      "directory": "src/node/routes",
       "line": 1,
-      "description": "code-server's routes live here."
+      "description": "code-server's routes live here in `src/node/routes` (see the explorer)."
     },
     {
       "file": "src/node/routes/index.ts",
@@ -128,9 +128,9 @@
       "description": "The service worker only exists to provide PWA functionality."
     },
     {
-      "file": "src/browser/pages",
+      "directory": "src/browser/pages",
       "line": 1,
-      "description": "HTML, CSS, and JavaScript for each page lives here. Currently our HTML uses a simple search and replace template system with variables that {{LOOK_LIKE_THIS}}."
+      "description": "HTML, CSS, and JavaScript for each page lives in here `src/browser/pages` (see the explorer). Currently our HTML uses a simple search and replace template system with variables that {{LOOK_LIKE_THIS}}."
     },
     {
       "file": "src/browser/pages/vscode.html",
@@ -138,9 +138,9 @@
       "description": "The VS Code HTML is based off VS Code's own `workbench.html`."
     },
     {
-      "file": "src/browser/media",
+      "directory": "src/browser/media",
       "line": 1,
-      "description": "Static images and the manifest live here."
+      "description": "Static images and the manifest live here in `src/browser/media` (see the explorer)."
     },
     {
       "file": "ci/dev/vscode.patch",

--- a/.tours/contributing.tour
+++ b/.tours/contributing.tour
@@ -145,7 +145,7 @@
     {
       "file": "ci/dev/vscode.patch",
       "line": 1,
-      "description": "code-server makes use of VS Code's frontend web/remote support. Most of the patch implements the remote server since that portion of the code is closed source and not released with VS Code.\n\nWe also have a few bug fixes and have added some features (like client-side extensions). See CONTRIBUTING.md for a list.\n\nWe make an effort to keep the patch as small as possible."
+      "description": "code-server makes use of VS Code's frontend web/remote support. Most of the patch implements the remote server since that portion of the code is closed source and not released with VS Code.\n\nWe also have a few bug fixes and have added some features (like client-side extensions). See [https://github.com/cdr/code-server/blob/master/doc/CONTRIBUTING.md#vs-code-patch](https://github.com/cdr/code-server/blob/master/doc/CONTRIBUTING.md#vs-code-patch) for a list.\n\nWe make an effort to keep the patch as small as possible."
     }
   ]
 }

--- a/.tours/contributing.tour
+++ b/.tours/contributing.tour
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Contributing",
+  "steps": [
+    {
+      "file": "src/node/app.ts",
+      "line": 11,
+      "description": "code-server's HTTP server is managed here."
+    },
+    {
+      "file": "src/node/routes/apps.ts",
+      "line": 8,
+      "description": "Apps can be created to extend code-server. Here is the Express route that handles that.",
+      "selection": {
+        "start": {
+          "line": 4,
+          "character": 1
+        },
+        "end": {
+          "line": 8,
+          "character": 4
+        }
+      }
+    },
+    {
+      "file": "src/node/routes/vscode.ts",
+      "line": 21,
+      "description": "This is the Express route for VS Code."
+    },
+    {
+      "file": "src/node/cli.ts",
+      "line": 28,
+      "description": "The `$ code-server` CLI is defined here. "
+    },
+    {
+      "file": "ci/dev/vscode.patch",
+      "line": 1,
+      "description": "In v1 of code-server, we had a patch of VS Code that split the codebase into a front-end and a server. The front-end consisted of all UI code, while the server ran the extensions and exposed an API to the front-end for file access and all UI needs.\n\nOver time, Microsoft added support to VS Code to run it on the web. They have made the front-end open source, but not the server. As such, code-server v2 (and later) uses the VS Code front-end and implements the server. You can find this here."
+    }
+  ],
+  "ref": "master"
+}

--- a/.tours/contributing.tour
+++ b/.tours/contributing.tour
@@ -3,7 +3,7 @@
   "title": "Contributing",
   "steps": [
     {
-      "file": "src",
+      "directory": "src",
       "line": 1,
       "description": "Hello world! code-server's source code lives here. It's broadly arranged into browser code, Node code, and code shared between both."
     },

--- a/.tours/contributing.tour
+++ b/.tours/contributing.tour
@@ -3,39 +3,149 @@
   "title": "Contributing",
   "steps": [
     {
-      "file": "src/node/app.ts",
-      "line": 11,
-      "description": "code-server's HTTP server is managed here."
+      "file": "src",
+      "line": 1,
+      "description": "Hello world! code-server's source code lives here. It's broadly arranged into browser code, Node code, and code shared between both."
     },
     {
-      "file": "src/node/routes/apps.ts",
-      "line": 8,
-      "description": "Apps can be created to extend code-server. Here is the Express route that handles that.",
-      "selection": {
-        "start": {
-          "line": 4,
-          "character": 1
-        },
-        "end": {
-          "line": 8,
-          "character": 4
-        }
-      }
-    },
-    {
-      "file": "src/node/routes/vscode.ts",
-      "line": 21,
-      "description": "This is the Express route for VS Code."
+      "file": "src/node/entry.ts",
+      "line": 157,
+      "description": "code-server begins execution here. CLI arguments are parsed, special flags like --help are handled, then the HTTP server is started."
     },
     {
       "file": "src/node/cli.ts",
       "line": 28,
-      "description": "The `$ code-server` CLI is defined here. "
+      "description": "This describes all of the code-server CLI options and how they will be parsed."
+    },
+    {
+      "file": "src/node/cli.ts",
+      "line": 233,
+      "description": "Here's the actual CLI parser."
+    },
+    {
+      "file": "src/node/settings.ts",
+      "line": 1,
+      "description": "code-server maintains a settings file that is read and written here."
+    },
+    {
+      "file": "src/node/app.ts",
+      "line": 11,
+      "description": "The core of code-server are HTTP and web socket servers which are created here. They provide authentication, file access, an API, and serve web-based applications like VS Code."
+    },
+    {
+      "file": "src/node/wsRouter.ts",
+      "line": 38,
+      "description": "This is an analog to Express's Router that handles web socket routes."
+    },
+    {
+      "file": "src/node/http.ts",
+      "line": 1,
+      "description": "This file provides various HTTP utility functions."
+    },
+    {
+      "file": "src/node/coder_cloud.ts",
+      "line": 9,
+      "description": "The cloud agent spawned here provides the --link functionality."
+    },
+    {
+      "file": "src/node/heart.ts",
+      "line": 7,
+      "description": "code-server's heart beats to indicate recent activity."
+    },
+    {
+      "file": "src/node/socket.ts",
+      "line": 13,
+      "description": "We pass sockets to child processes, however we can't pass TLS sockets so when code-server is handling TLS (via --cert) we use this to create a proxy that can be passed to the child."
+    },
+    {
+      "file": "src/node/routes",
+      "line": 1,
+      "description": "code-server's routes live here."
+    },
+    {
+      "file": "src/node/routes/index.ts",
+      "line": 123,
+      "description": "The architecture of code-server allows it to be extended with applications via plugins. Each application is registered at its own route and handles requests at and below that route. Currently we have only VS Code (although it is not yet actually split out into a plugin)."
+    },
+    {
+      "file": "src/node/plugin.ts",
+      "line": 103,
+      "description": "The previously mentioned plugins are loaded here."
+    },
+    {
+      "file": "src/node/routes/apps.ts",
+      "line": 12,
+      "description": "This provides a list of the applications registered with code-server."
+    },
+    {
+      "file": "src/node/routes/domainProxy.ts",
+      "line": 18,
+      "description": "code-server provides a built-in proxy to help in developing web-based applications. This is the code for the domain-based proxy."
+    },
+    {
+      "file": "src/node/routes/pathProxy.ts",
+      "line": 19,
+      "description": "Here is the path-based version of the proxy."
+    },
+    {
+      "file": "src/node/proxy.ts",
+      "line": 4,
+      "description": "Both the domain and path proxy use the single proxy instance created here."
+    },
+    {
+      "file": "src/node/routes/health.ts",
+      "line": 5,
+      "description": "A simple endpoint that lets you see if code-server is up."
+    },
+    {
+      "file": "src/node/routes/login.ts",
+      "line": 46,
+      "description": "code-server supports a password-based login here."
+    },
+    {
+      "file": "src/node/routes/static.ts",
+      "line": 16,
+      "description": "This serves static assets. Anything under the code-server directory can be fetched. Anything outside requires authentication."
+    },
+    {
+      "file": "src/node/routes/update.ts",
+      "line": 10,
+      "description": "This endpoint lets you query for the latest code-server version. It's used to power the update popup you see in VS Code."
+    },
+    {
+      "file": "src/node/routes/vscode.ts",
+      "line": 15,
+      "description": "This is the endpoint that serves VS Code's HTML, handles VS Code's websockets, and handles a few VS Code-specific endpoints for fetching static files."
+    },
+    {
+      "file": "src/node/vscode.ts",
+      "line": 13,
+      "description": "The actual VS Code spawn and initialization is handled here. VS Code runs in a separate child process. We communicate via IPC and by passing it web sockets."
+    },
+    {
+      "file": "src/browser/serviceWorker.ts",
+      "line": 1,
+      "description": "The service worker only exists to provide PWA functionality."
+    },
+    {
+      "file": "src/browser/pages",
+      "line": 1,
+      "description": "HTML, CSS, and JavaScript for each page lives here. Currently our HTML uses a simple search and replace template system with variables that {{LOOK_LIKE_THIS}}."
+    },
+    {
+      "file": "src/browser/pages/vscode.html",
+      "line": 1,
+      "description": "The VS Code HTML is based off VS Code's own `workbench.html`."
+    },
+    {
+      "file": "src/browser/media",
+      "line": 1,
+      "description": "Static images and the manifest live here."
     },
     {
       "file": "ci/dev/vscode.patch",
       "line": 1,
-      "description": "In v1 of code-server, we had a patch of VS Code that split the codebase into a front-end and a server. The front-end consisted of all UI code, while the server ran the extensions and exposed an API to the front-end for file access and all UI needs.\n\nOver time, Microsoft added support to VS Code to run it on the web. They have made the front-end open source, but not the server. As such, code-server v2 (and later) uses the VS Code front-end and implements the server. You can find this here."
+      "description": "code-server makes use of VS Code's frontend web/remote support. Most of the patch implements the remote server since that portion of the code is closed source and not released with VS Code.\n\nWe also have a few bug fixes and have added some features (like client-side extensions). See CONTRIBUTING.md for a list.\n\nWe make an effort to keep the patch as small as possible."
     }
   ],
   "ref": "master"

--- a/.tours/contributing.tour
+++ b/.tours/contributing.tour
@@ -147,6 +147,5 @@
       "line": 1,
       "description": "code-server makes use of VS Code's frontend web/remote support. Most of the patch implements the remote server since that portion of the code is closed source and not released with VS Code.\n\nWe also have a few bug fixes and have added some features (like client-side extensions). See CONTRIBUTING.md for a list.\n\nWe make an effort to keep the patch as small as possible."
     }
-  ],
-  "ref": "master"
+  ]
 }

--- a/.tours/start-development.tour
+++ b/.tours/start-development.tour
@@ -5,7 +5,7 @@
     {
       "file": "package.json",
       "line": 31,
-      "description": "## Commands\n\nTo start developing, make sure you have Node 12+ installed. Then, run the following commands:\n\n1. Install dependencies:\n>> yarn\n\n2. Clone, patch, and install VS Code:\n>> yarn vscode\n\n3. Start development mode (and watch for changes):\n>> yarn watch"
+      "description": "## Commands\n\nTo start developing, make sure you have Node 12+ and the [required dependencies](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#prerequisites) installed. Then, run the following commands:\n\n1. Install dependencies:\n>> yarn\n\n2. Clone and patch VS Code and install its dependencies:\n>> yarn vscode\n\n3. Start development mode (and watch for changes):\n>> yarn watch"
     },
     {
       "file": "src/node/app.ts",

--- a/.tours/start-development.tour
+++ b/.tours/start-development.tour
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://aka.ms/codetour-schema",
+  "title": "Start Development",
+  "steps": [
+    {
+      "file": "package.json",
+      "line": 31,
+      "description": "## Commands\n\nTo start developing, make sure you have Node 12+ installed. Then, run the following commands:\n\n1. Install dependencies:\n>> yarn\n\n2. Clone, patch, and install VS Code:\n>> yarn vscode\n\n3. Start development mode (and watch for changes):\n>> yarn watch"
+    },
+    {
+      "file": "src/node/app.ts",
+      "line": 68,
+      "description": "## Visit the web server\n\nIf all goes well, you should see something like this in your terminal. code-server should be live in development mode.\n\n---\n```bash\n[2020-12-09T21:03:37.156Z] info  code-server 3.7.4 development\n[2020-12-09T21:03:37.157Z] info  Using user-data-dir ~/.local/share/code-server\n[2020-12-09T21:03:37.165Z] info  Using config file ~/.config/code-server/config.yaml\n[2020-12-09T21:03:37.165Z] info  HTTP server listening on http://127.0.0.1:8080 \n[2020-12-09T21:03:37.165Z] info    - Authentication is enabled\n[2020-12-09T21:03:37.165Z] info      - Using password from ~/.config/code-server/config.yaml\n[2020-12-09T21:03:37.165Z] info    - Not serving HTTPS\n```\n\n---\n\nIf you have the default configuration, you can access it at [http://localhost:8080](http://localhost:8080)."
+    },
+    {
+      "file": "src/browser/pages/login.html",
+      "line": 26,
+      "description": "## Make a change\n\nThis is the login page, let's make a change and see it update on our web server! Perhaps change the text :)\n\n```html\n<div class=\"sub\">Modifying the login page 👨🏼‍💻</div>\n```\n\nReminder, you can likely preview at [http://localhost:8080](http://localhost:8080)"
+    },
+    {
+      "file": "src/node/app.ts",
+      "line": 62,
+      "description": "## That's it!\n\n\nThat's all there is to it! When this tour ends, your terminal session may stop, but just use `yarn watch` to start developing from here on out!\n\n\nIf you haven't already, be sure to check out these resources:\n- [Tour: Contributing](command:codetour.startTourByTitle?[\"Contributing\")\n- [Docs: FAQ.md](https://github.com/cdr/code-server/blob/master/doc/FAQ.md)\n- [Docs: CONTRIBUTING.md](https://github.com/cdr/code-server/blob/master/doc/CONTRIBUTING.md)\n- [Community: GitHub Discussions](https://github.com/cdr/code-server/discussions)\n- [Community: Slack](https://community.coder.com)"
+    }
+  ]
+}


### PR DESCRIPTION
The [CodeTour](https://marketplace.visualstudio.com/items?itemName=vsls-contrib.codetour) extension for VS Code gives users an interactive walkthrough of a codebase.

When the repo is first cloned (and the CodeTour extension is installed), a dialog appears with the option to start a tour.

![code-server tour](https://user-images.githubusercontent.com/22407953/101365152-47ee2900-3858-11eb-8998-253414851204.gif)

Tours can be viewed, edited, and "recorded" with the extension, or through editing the `.tour` file. I have created a a basic tour, but would love input from @code-asher and others on what areas of codebase to point new contributors to.

Since code-server is well-documented, perhaps this can be used as a way to show people what files are important. CodeTours can also prompt users to [execute shell commands](https://user-images.githubusercontent.com/116461/78858896-91912600-79e2-11ea-8002-196c12273ebc.gif). This could be used to help with onboarding or to run tests for the first time!