### PR TITLE
install.sh: Use $ID_LIKE to detect distro

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -238,10 +238,10 @@ main() {
   macos)
     install_macos
     ;;
-  ubuntu | debian | raspbian)
+  debian)
     install_deb
     ;;
-  centos | fedora | rhel | opensuse)
+  fedora | opensuse)
     install_rpm
     ;;
   arch)
@@ -425,14 +425,16 @@ os() {
 }
 
 # distro prints the detected operating system including linux distros.
+# Also parses ID_LIKE for common distro bases.
 #
 # Example outputs:
-# - macos
-# - debian, ubuntu, raspbian
-# - centos, fedora, rhel, opensuse
-# - alpine
-# - arch
-# - freebsd
+# - macos -> macos
+# - freebsd -> freebsd
+# - ubuntu, raspbian, debian ... -> debian
+# - amzn, centos, rhel, fedora, ... -> fedora
+# - opensuse-{leap,tumbleweed} -> opensuse
+# - alpine -> alpine
+# - arch -> arch
 #
 # Inspired by https://github.com/docker/docker-install/blob/26ff363bcf3b3f5a00498ac43694bf1c7d9ce16c/install.sh#L111-L120.
 distro() {
@@ -444,12 +446,15 @@ distro() {
   if [ -f /etc/os-release ]; then
     (
       . /etc/os-release
-      case "$ID" in opensuse-*)
-        # opensuse's ID's look like opensuse-leap and opensuse-tumbleweed.
-        echo "opensuse"
-        return
-        ;;
-      esac
+      if [ "${ID_LIKE-}" ]; then
+        for id_like in $ID_LIKE; do
+          case "$id_like" in debian | fedora | opensuse)
+            echo "$id_like"
+            return
+            ;;
+          esac
+        done
+      fi
 
       echo "$ID"
     )


### PR DESCRIPTION
Update the install script to use `$ID_LIKE` where possible to detect similar distros.
Script now detects Amazon Linux as a .rpm-based distro; also de-duplicated checks for other distros.

Tested to work on:
- Alpine Linux, `ash`
- Amazon Linux, `bash`
- Arch Linux, `bash`
- Ubuntu, `dash`

Fixes #2343.