### PR TITLE
cli: Show beta flags in help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ We also have an in-depth [setup and configuration](./doc/guide.md) guide.
 ### Cloud Program ☁️
 
 We're working on a cloud platform that makes deploying and managing code-server easier.
-Consider running code-server with the flag `--link` if you don't want to worry about
+Consider running code-server with the beta flag `--link` if you don't want to worry about
 
 - TLS
 - Authentication

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -74,7 +74,7 @@ interface Option<T> {
   description?: string
 
   /**
-   * If marked as beta, the option is not printed unless $CS_BETA is set.
+   * If marked as beta, the option is marked as beta in help.
    */
   beta?: boolean
 }
@@ -194,6 +194,7 @@ const options: Options<Required<Args>> = {
       https://myname.coder-cloud.com at which you can easily access your code-server instance.
       Authorization is done via GitHub.
     `,
+    beta: true,
   },
 }
 
@@ -206,32 +207,24 @@ export const optionDescriptions = (): string[] => {
     }),
     { short: 0, long: 0 },
   )
-  return entries
-    .filter(([, v]) => {
-      // If CS_BETA is set, we show beta options but if not, then we do not want
-      // to show beta options.
-      return process.env.CS_BETA || !v.beta
-    })
-    .map(([k, v]) => {
-      const help = `${" ".repeat(widths.short - (v.short ? v.short.length : 0))}${
-        v.short ? `-${v.short}` : " "
-      } --${k} `
-      return (
-        help +
-        v.description
-          ?.trim()
-          .split(/\n/)
-          .map((line, i) => {
-            line = line.trim()
-            if (i === 0) {
-              return " ".repeat(widths.long - k.length) + line
-            }
-            return " ".repeat(widths.long + widths.short + 6) + line
-          })
-          .join("\n") +
-        (typeof v.type === "object" ? ` [${Object.values(v.type).join(", ")}]` : "")
-      )
-    })
+  return entries.map(([k, v]) => {
+    const help = `${" ".repeat(widths.short - (v.short ? v.short.length : 0))}${v.short ? `-${v.short}` : " "} --${k} `
+    return (
+      help +
+      v.description
+        ?.trim()
+        .split(/\n/)
+        .map((line, i) => {
+          line = line.trim()
+          if (i === 0) {
+            return " ".repeat(widths.long - k.length) + (v.beta ? "(beta) " : "") + line
+          }
+          return " ".repeat(widths.long + widths.short + 6) + line
+        })
+        .join("\n") +
+      (typeof v.type === "object" ? ` [${Object.values(v.type).join(", ")}]` : "")
+    )
+  })
 }
 
 export const parse = (


### PR DESCRIPTION
Looks like

```
   -r --reuse-window         Force to open a file or folder in an already opened window.
 -vvv --verbose              Enable verbose logging.
      --link                 (beta) Securely bind code-server via Coder Cloud with the passed name. You'll get a URL like
                             https://myname.coder-cloud.com at which you can easily access your code-server instance.
                             Authorization is done via GitHub.
```

Based on commits by @JammSpread in #2405

Closes #2396
