### PR TITLE
Add GET authentication

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -150,7 +150,7 @@ const options: Options<Required<Args>> = {
   socket: { type: "string", path: true, description: "Path to a socket (bind-addr will be ignored)." },
   "enable-get-requests": {
     type: "boolean",
-    description: `Enable authentication via the url with queries. (Usage: ?pass=[password] after the rest of the url)`
+    description: `Enable authentication via the url with a query parameter. (Usage: ?pass=[password] after the rest of the url.)`
   },
   version: { type: "boolean", short: "v", description: "Display version information." },
   _: { type: "string[]" },

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -562,6 +562,31 @@ export async function readConfigFile(configPath?: string): Promise<ConfigArgs> {
   }
 }
 
+export async function writeConfigFile(configPath?: string, data? : object) {
+  if (!configPath) {
+    configPath = process.env.CODE_SERVER_CONFIG
+    if (!configPath) {
+      configPath = path.join(paths.config, "config.yaml")
+    }
+  }
+
+  if (!(await fs.pathExists(configPath))) {
+    await fs.outputFile(configPath, await defaultConfigFile())
+    logger.info(`Wrote default config file to ${humanPath(configPath)}`)
+  }
+
+  const configFile = await fs.readFile(configPath)
+  const config = yaml.safeLoad(configFile.toString(), {
+    filename: configPath,
+  })
+  if (!config || typeof config === "string") {
+    throw new Error(`invalid config: ${config}`)
+  }
+
+  const dumpedData = yaml.safeDump({...config, ...data});
+  await fs.outputFile(configPath, dumpedData)
+}
+
 function parseBindAddr(bindAddr: string): Addr {
   const u = new URL(`http://${bindAddr}`)
   return {

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -47,6 +47,7 @@ export interface Args extends VsArgs {
   tokens?: string[]
   "generate-token"?: boolean
   "list-tokens"?: boolean
+  "revoke-token"?: string
   version?: boolean
   force?: boolean
   "list-extensions"?: boolean
@@ -167,6 +168,10 @@ const options: Options<Required<Args>> = {
   "generate-token": {
     type: "boolean",
     description: "Generate a new token for quick access."
+  },
+  "revoke-token": {
+    type: "string",
+    description: "Remove and disable a specific token from use."
   },
   version: { type: "boolean", short: "v", description: "Display version information." },
   _: { type: "string[]" },

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -43,6 +43,7 @@ export interface Args extends VsArgs {
   port?: number
   "bind-addr"?: string
   socket?: string
+  "enable-get-requests"?: boolean
   version?: boolean
   force?: boolean
   "list-extensions"?: boolean
@@ -147,6 +148,10 @@ const options: Options<Required<Args>> = {
   port: { type: "number", description: "" },
 
   socket: { type: "string", path: true, description: "Path to a socket (bind-addr will be ignored)." },
+  "enable-get-requests": {
+    type: "boolean",
+    description: `Enable authentication via the url with queries. (Usage: ?pass=[password] after the rest of the url)`
+  },
   version: { type: "boolean", short: "v", description: "Display version information." },
   _: { type: "string[]" },
 

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -44,6 +44,9 @@ export interface Args extends VsArgs {
   "bind-addr"?: string
   socket?: string
   "enable-get-requests"?: boolean
+  tokens?: string[]
+  "generate-token"?: boolean
+  "list-tokens"?: boolean
   version?: boolean
   force?: boolean
   "list-extensions"?: boolean
@@ -151,6 +154,19 @@ const options: Options<Required<Args>> = {
   "enable-get-requests": {
     type: "boolean",
     description: `Enable authentication via the url with a query parameter. (Usage: ?pass=[password] after the rest of the url.)`
+  },
+  "tokens": {
+    type: "string[]",
+    description: ""
+  },
+  "list-tokens": {
+    type: "boolean",
+    short: "t",
+    description: "List currently active tokens."
+  },
+  "generate-token": {
+    type: "boolean",
+    description: "Generate a new token for quick access."
   },
   version: { type: "boolean", short: "v", description: "Display version information." },
   _: { type: "string[]" },

--- a/src/node/entry.ts
+++ b/src/node/entry.ts
@@ -125,6 +125,10 @@ const main = async (args: DefaultedArgs): Promise<void> => {
     logger.info(`  - Authentication is disabled ${args.link ? "(disabled by --link)" : ""}`)
   }
 
+  if (args["enable-get-requests"]) {
+    logger.info(`  - Login via GET is enabled ${args.auth === AuthType.None ? "(however auth is disabled)" : ""}`)
+  }
+
   if (args.cert) {
     logger.info(`  - Using certificate for HTTPS: ${humanPath(args.cert.value)}`)
   } else {

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -109,9 +109,8 @@ router.get("/", async (req : Request, res : Response) => {
     // `?password` overrides `?pass`
     if (req.query.password && typeof req.query.password === "string") {
       return await login(req, res, req.query.password)
-    }
-    else if (req.query.pass) {
-      return await login(req, res, req.query.pass as string)
+} else if (req.query.pass && typeof req.query.pass === "string") {
+      return await login(req, res, req.query.pass)
     }
   }
   res.send(await getRoot(req))

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -1,4 +1,4 @@
-import { Router, Request } from "express"
+import { Router, Request, Response, NextFunction } from "express"
 import { promises as fs } from "fs"
 import { RateLimiter as Limiter } from "limiter"
 import * as path from "path"
@@ -43,7 +43,7 @@ const getRoot = async (req: Request, error?: Error): Promise<string> => {
 
 const limiter = new RateLimiter()
 
-const login = async (req : Request, res : any, password : string) => {
+const login = async (req : Request, res : Response, password : string) => {
   try {
     if (!limiter.try()) {
       throw new Error("Login rate limited!")
@@ -92,7 +92,7 @@ const login = async (req : Request, res : any, password : string) => {
 
 export const router = Router()
 
-router.use((req : any, res : any, next : any) => {
+router.use((req : Request, res : Response, next : NextFunction) => {
   const to = (typeof req.query.to === "string" && req.query.to) || "/"
   if (authenticated(req)) {
     return redirect(req, res, to, {
@@ -104,7 +104,7 @@ router.use((req : any, res : any, next : any) => {
   next()
 })
 
-router.get("/", async (req : any, res : any) => {
+router.get("/", async (req : Request, res : Response) => {
   if (req.args["enable-get-requests"]) {
     // `?password` overrides `?pass`
     if (req.query.password) {
@@ -117,6 +117,6 @@ router.get("/", async (req : any, res : any) => {
   res.send(await getRoot(req))
 })
 
-router.post("/", async (req : any, res : any) => {
+router.post("/", async (req : Request, res : Response) => {
   await login(req, res, req.body.password)
 })

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -107,8 +107,8 @@ router.use((req : Request, res : Response, next : NextFunction) => {
 router.get("/", async (req : Request, res : Response) => {
   if (req.args["enable-get-requests"]) {
     // `?password` overrides `?pass`
-    if (req.query.password) {
-      return await login(req, res, req.query.password as string)
+    if (req.query.password && typeof req.query.password === "string") {
+      return await login(req, res, req.query.password)
     }
     else if (req.query.pass) {
       return await login(req, res, req.query.pass as string)


### PR DESCRIPTION
Adds config option `enable-get-requests` to enable authentication in the URL.
(i.e. logging in on someone going to a link like, **192.168.1.49:8080/login?pass=SamplePassword**)
This pr adds both the password and pass queries with the password query taking higher precedence in the URL.

This may have functionality when sharing a workspace with someone trusted.

Issues that had mentioned this ability:
- #1236
- #1285
- #1669