### PR TITLE
docs: Update nginx certbot to use python3

### DIFF
--- a/.github/ISSUE_TEMPLATE/extension-request.md
+++ b/.github/ISSUE_TEMPLATE/extension-request.md
@@ -3,7 +3,7 @@ name: Extension request
 about: Request an extension missing from the code-server marketplace
 title: ""
 labels: extension-request
-assignees: cmoog
+assignees: ""
 ---
 
 <!--

--- a/doc/guide.md
+++ b/doc/guide.md
@@ -215,7 +215,7 @@ If you prefer to use NGINX instead of Caddy then please follow steps 1-2 above a
 
 ```bash
 sudo apt update
-sudo apt install -y nginx certbot python-certbot-nginx
+sudo apt install -y nginx certbot python3-certbot-nginx
 ```
 
 4. Put the following config into `/etc/nginx/sites-available/code-server` with sudo:


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the master branch!
-->
docs: Update nginx certbot to use python3
issue: #2436 