### PR TITLE
release-image: Change default coder shell to /bin/bash

### DIFF
--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -45,4 +45,5 @@ EXPOSE 8080
 USER 1000
 ENV USER=coder
 WORKDIR /home/coder
+RUN sudo chsh -s /bin/bash
 ENTRYPOINT ["/usr/bin/entrypoint.sh", "--bind-addr", "0.0.0.0:8080", "."]


### PR DESCRIPTION
Closes #2410
