### PR TITLE
release-image: Remove unnecessary call to chsh

### DIFF
--- a/ci/release-image/Dockerfile
+++ b/ci/release-image/Dockerfile
@@ -21,9 +21,6 @@ RUN sed -i "s/# en_US.UTF-8/en_US.UTF-8/" /etc/locale.gen \
   && locale-gen
 ENV LANG=en_US.UTF-8
 
-RUN chsh -s /bin/bash
-ENV SHELL=/bin/bash
-
 RUN adduser --gecos '' --disabled-password coder && \
   echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
 


### PR DESCRIPTION
Confused me in #2410, see #2455

debian:10 defaults to bash as $SHELL
