### PR TITLE
feat(local development): add vscode:clean script

### DIFF
--- a/ci/dev/reset-vscode.sh
+++ b/ci/dev/reset-vscode.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+  cd "$(dirname "$0")/../.."
+
+  cd ./lib/vscode
+  git add -A
+  git reset --hard
+}
+
+main "$@"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "vscode": "./ci/dev/vscode.sh",
     "vscode:patch": "./ci/dev/patch-vscode.sh",
     "vscode:diff": "./ci/dev/diff-vscode.sh",
+    "vscode:reset": "./ci/dev/reset-vscode.sh",
     "build": "./ci/build/build-code-server.sh",
     "build:vscode": "./ci/build/build-vscode.sh",
     "release": "./ci/build/build-release.sh",


### PR DESCRIPTION
This PR adds a new script to the root `package.json` called `vscode:clean` which resets `lib/vscode`. 

## Changes
- add script to `./ci/dev/clean-vscode.sh`
- add script `vscode:clean` to `package.json` at root

## Screenshots
![2020-12-15 12 40 00](https://user-images.githubusercontent.com/3806031/102264967-9db77680-3ed3-11eb-9556-1b3a4f3e5770.gif)

## Checklist
- [x] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

Fixes N/A (no accompanying issue) 