### PR TITLE
Small changes to the hashed-password FAQ

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -172,6 +172,13 @@ printf "thisismypassword" | sha256sum | cut -d' ' -f1
 
 Of course replace `"thisismypassword"` with your actual password.
 
+Example:
+
+```yaml
+auth: password
+hashed-password: 1da9133ab9dbd11d2937ec8d312e1e2569857059e73cc72df92e670928983ab5 # You got this from the command above
+```
+
 ## How do I securely access web services?
 
 code-server is capable of proxying to any port using either a subdomain or a

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -167,7 +167,7 @@ Again, please follow [./guide.md](./guide.md) for our recommendations on setting
 Yes you can! Use `hashed-password` instead of `password`. Generate the hash with:
 
 ```
-echo "thisismypassword" | sha256sum | cut -d' ' -f1
+printf "thisismypassword" | sha256sum | cut -d' ' -f1
 ```
 
 Of course replace `"thisismypassword"` with your actual password.

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -170,7 +170,7 @@ Yes you can! Set the value of `hashed-password` instead of `password`. Generate 
 printf "thisismypassword" | sha256sum | cut -d' ' -f1
 ```
 
-Of course replace `"thisismypassword"` with your actual password.
+Of course replace `thisismypassword` with your actual password.
 
 Example:
 

--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -164,7 +164,7 @@ Again, please follow [./guide.md](./guide.md) for our recommendations on setting
 
 ## Can I store my password hashed?
 
-Yes you can! Use `hashed-password` instead of `password`. Generate the hash with:
+Yes you can! Set the value of `hashed-password` instead of `password`. Generate the hash with:
 
 ```
 printf "thisismypassword" | sha256sum | cut -d' ' -f1


### PR DESCRIPTION
See also https://github.com/cdr/code-server/issues/2225#issuecomment-752687041

- Changed `echo` to `printf` to avoid newlines.
- Added an example to make it clear which `password` should be changed to `hashed-password`.
- Removed the double quotes from the sentence ``Of course replace `"thisismypassword"` with your actual password.`` to avoid potential confusion.