### PR TITLE
vscode.ts: Fix close current folder

### DIFF
--- a/src/node/vscode.ts
+++ b/src/node/vscode.ts
@@ -37,14 +37,18 @@ export class VscodeProvider {
     query: ipc.Query,
   ): Promise<ipc.WorkbenchOptions> {
     const { lastVisited } = await settings.read()
-    const startPath = await this.getFirstPath([
+    let startPath = await this.getFirstPath([
       { url: query.workspace, workspace: true },
       { url: query.folder, workspace: false },
       options.args._ && options.args._.length > 0
         ? { url: path.resolve(options.args._[options.args._.length - 1]) }
         : undefined,
-      !options.args["ignore-last-opened"]  && !query.ew ? lastVisited : undefined,
+      !options.args["ignore-last-opened"] ? lastVisited : undefined,
     ])
+
+    if (query.ew) {
+      startPath = undefined
+    }
 
     settings.write({
       lastVisited: startPath,

--- a/src/node/vscode.ts
+++ b/src/node/vscode.ts
@@ -43,7 +43,7 @@ export class VscodeProvider {
       options.args._ && options.args._.length > 0
         ? { url: path.resolve(options.args._[options.args._.length - 1]) }
         : undefined,
-      !options.args["ignore-last-opened"] ? lastVisited : undefined,
+      !options.args["ignore-last-opened"]  && !query.ew ? lastVisited : undefined,
     ])
 
     settings.write({


### PR DESCRIPTION
Fixes VscodeProvider to correctly obey the ew parameter.

Based on changes by @rdbeach. See the previous commit.