### PR TITLE
doc/guide.md: Update caddy install instructions

### DIFF
--- a/doc/guide.md
+++ b/doc/guide.md
@@ -180,8 +180,9 @@ Assuming you have been following the guide, edit your instance and checkmark the
 3. Install caddy https://caddyserver.com/docs/download#debian-ubuntu-raspbian.
 
 ```bash
-echo "deb [trusted=yes] https://apt.fury.io/caddy/ /" \
-    | sudo tee -a /etc/apt/sources.list.d/caddy-fury.list
+sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/gpg/gpg.155B6D79CA56EA34.key' | sudo apt-key add -
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/cfg/setup/config.deb.txt?distro=debian&version=any-version' | sudo tee -a /etc/apt/sources.list.d/caddy-stable.list
 sudo apt update
 sudo apt install caddy
 ```


### PR DESCRIPTION
Caddy has new installation instructions for Debian.

Closes #2599

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the master branch!
-->
