### PR TITLE
Allow use of multiple extension galleries

### DIFF
--- a/lib/vscode/src/vs/platform/product/common/productService.ts
+++ b/lib/vscode/src/vs/platform/product/common/productService.ts
@@ -69,7 +69,7 @@ export interface IProductConfiguration {
 	readonly experimentsUrl?: string;
 
 	readonly extensionsGallery?: {
-		readonly serviceUrl: string;
+		readonly serviceUrl: string[];
 		readonly itemUrl: string;
 		readonly controlUrl: string;
 		readonly recommendationsUrl: string;

--- a/lib/vscode/src/vs/server/ipc.d.ts
+++ b/lib/vscode/src/vs/server/ipc.d.ts
@@ -125,7 +125,7 @@ export interface WorkbenchOptions {
 	readonly productConfiguration: {
 		codeServerVersion?: string;
 		readonly extensionsGallery?: {
-			readonly serviceUrl: string;
+			readonly serviceUrl: string[];
 			readonly itemUrl: string;
 			readonly controlUrl: string;
 			readonly recommendationsUrl: string;

--- a/lib/vscode/src/vs/server/node/marketplace.ts
+++ b/lib/vscode/src/vs/server/node/marketplace.ts
@@ -160,7 +160,7 @@ const extractTar = async (tarPath: string, targetPath: string, options: IExtract
  */
 export const enableCustomMarketplace = (): void => {
 	(<any>product).extensionsGallery = { // Use `any` to override readonly.
-		serviceUrl: process.env.SERVICE_URL || 'https://extensions.coder.com/api',
+		serviceUrl: process.env.SERVICE_URL ? [process.env.SERVICE_URL] : ['https://open-vsx.org/vscode/gallery', 'https://extensions.coder.com/api'],
 		itemUrl: process.env.ITEM_URL || '',
 		controlUrl: '',
 		recommendationsUrl: '',


### PR DESCRIPTION
This PR should implement support for using multiple extension galleries by default.
There's quite a few things that may be slightly hacky about it, since VSCode's extension gallery design is confusingly broken:

- `galleryUrl` is used for `/extensionquery` and uninstall statistics
- `itemUrl` is supposedly used for linking to item pages but is not essential for functionality (and our gallery doesn't support it) so I just left it out
- `controlUrl` appears to be used for reporting malicious extensions, neither OpenVSX nor our gallery supports this
- `recommendationsUrl` provides recommendations but neither OpenVSX nor our gallery supports this

Awkward thing here is that `galleryUrl` on first glance appears to be the base URL for the whole API, and internally `/extensionquery` is appended to it, but then they go ahead and include separate URLs for other extension gallery functionality - which is quite confusing.

So, I just changed the type of `galleryUrl` from `string` to `string[]` and patched the methods that read from it.

It might also be possible to change the type of `extensionGallery` to a list of objects instead of an object with a list of `galleryUrl` - but given that the other variables aren't really used by either of the two galleries we plan to primarily support (ours and OpenVSX's), so I tried to minimize engineering time there.

I've tested the result by installing extensions from both OpenVSX and our repo - and it works fine!

Also, right now, I don't actually resort results to merge the two lists; it's just all of OpenVSX's first page, with all of Coder's (with duplicates filtered) after that.