### PR TITLE
Send 'loaded' event to all parent origins

### DIFF
--- a/lib/vscode/src/vs/server/browser/client.ts
+++ b/lib/vscode/src/vs/server/browser/client.ts
@@ -102,7 +102,7 @@ export const initialize = async (services: ServiceCollection): Promise<void> => 
 
 	if (parent) {
 		// Tell the parent loading has completed.
-		parent.postMessage({ event: 'loaded' }, window.location.origin);
+		parent.postMessage({ event: 'loaded' }, '*');
 
 		// Proxy or stop proxing events as requested by the parent.
 		const listeners = new Map<string, (event: Event) => void>();


### PR DESCRIPTION
This event isn't sensitive, so it should be sent to all parent origins. Some situations may require running an iframe to code-server on a separate domain to the code-server instance, and they might want to listen to this event.

`window.location.origin` limited this event to only the same domain.

This does not change the iframe behavior in any other way. Iframes are still allowed by default unless explicitly blocked via response headers or another mechanism.