### PR TITLE
echo without newline to hash password

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -167,7 +167,7 @@ Again, please follow [./guide.md](./guide.md) for our recommendations on setting
 Yes you can! Use `hashed-password` instead of `password`. Generate the hash with:
 
 ```
-echo "thisismypassword" | sha256sum | cut -d' ' -f1
+echo -n "thisismypassword" | sha256sum | cut -d' ' -f1
 ```
 
 Of course replace `"thisismypassword"` with your actual password.


### PR DESCRIPTION
Otherwise the input to sha256sum will include the newline character

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the master branch!
-->
