### PR TITLE
feat(testing): add unit tests for common/util

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -1,11 +1,12 @@
 {
-  "#": "We must put jest in a sub-directory otherwise VS Code somehow picks up",
   "#": "the types and generates conflicts with mocha.",
   "devDependencies": {
     "@types/jest": "^26.0.20",
+    "@types/jsdom": "^16.2.6",
     "@types/node-fetch": "^2.5.8",
     "@types/supertest": "^2.0.10",
     "jest": "^26.6.3",
+    "jsdom": "^16.4.0",
     "node-fetch": "^2.6.1",
     "playwright": "^1.8.0",
     "supertest": "^6.1.1",

--- a/test/package.json
+++ b/test/package.json
@@ -1,5 +1,5 @@
 {
-  "#": "the types and generates conflicts with mocha.",
+  "#": "We must put jest in a sub-directory otherwise VS Code somehow picks up the types and generates conflicts with mocha.",
   "devDependencies": {
     "@types/jest": "^26.0.20",
     "@types/jsdom": "^16.2.6",

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,4 +1,7 @@
-import { normalize } from "../src/common/util"
+import { logger as l } from "@coder/logger"
+import { arrayify, getFirstString, normalize, plural, resolveBase, split, trimSlashes } from "../src/common/util"
+
+type LocationLike = Pick<Location, "pathname" | "origin">
 
 describe("util", () => {
   describe("normalize", () => {
@@ -13,6 +16,108 @@ describe("util", () => {
     it("should preserve trailing slash if it exists", () => {
       expect(normalize("qux///", true)).toBe("qux/")
       expect(normalize("qux", true)).toBe("qux")
+    })
+  })
+
+  describe("split", () => {
+    it("should split at a comma", () => {
+      expect(split("Hello,world", ",")).toStrictEqual(["Hello", "world"])
+    })
+
+    it("shouldn't split if the delimiter doesn't exist", () => {
+      expect(split("Hello world", ",")).toStrictEqual(["Hello world", ""])
+    })
+  })
+
+  describe("plural", () => {
+    it("should add an s if count is greater than 1", () => {
+      expect(plural(2, "dog")).toBe("dogs")
+    })
+    it("should NOT add an s if the count is 1", () => {
+      expect(plural(1, "dog")).toBe("dog")
+    })
+  })
+
+  describe("trimSlashes", () => {
+    it("should remove leading slashes", () => {
+      expect(trimSlashes("/hello-world")).toBe("hello-world")
+    })
+
+    it("should remove trailing slashes", () => {
+      expect(trimSlashes("hello-world/")).toBe("hello-world")
+    })
+
+    it("should remove both leading and trailing slashes", () => {
+      expect(trimSlashes("/hello-world/")).toBe("hello-world")
+    })
+
+    it("should remove multiple leading and trailing slashes", () => {
+      expect(trimSlashes("///hello-world////")).toBe("hello-world")
+    })
+  })
+
+  describe("resolveBase", () => {
+    beforeEach(() => {
+      const location: LocationLike = {
+        pathname: "/healthz",
+        origin: "http://localhost:8080",
+      }
+
+      // Because resolveBase is not a pure function
+      // and relies on the global location to be set
+      // we set it before all the tests
+      // and tell TS that our location should be looked at
+      // as Location (even though it's missing some properties)
+      global.location = location as Location
+    })
+
+    it("should resolve a base", () => {
+      expect(resolveBase("localhost:8080")).toBe("/localhost:8080")
+    })
+
+    it("should resolve a base with a forward slash at the beginning", () => {
+      expect(resolveBase("/localhost:8080")).toBe("/localhost:8080")
+    })
+
+    it("should resolve a base with query params", () => {
+      expect(resolveBase("localhost:8080?folder=hello-world")).toBe("/localhost:8080")
+    })
+
+    it("should resolve a base with a path", () => {
+      expect(resolveBase("localhost:8080/hello/world")).toBe("/localhost:8080/hello/world")
+    })
+
+    it("should resolve a base to an empty string when not provided", () => {
+      expect(resolveBase()).toBe("")
+    })
+  })
+
+  describe("arrayify", () => {
+    it("should return value it's already an array", () => {
+      expect(arrayify(["hello", "world"])).toStrictEqual(["hello", "world"])
+    })
+    it("should wrap the value in an array if not an array", () => {
+      expect(
+        arrayify({
+          name: "Coder",
+          version: "3.8",
+        }),
+      ).toStrictEqual([{ name: "Coder", version: "3.8" }])
+    })
+    it("should return an empty array if the value is undefined", () => {
+      expect(arrayify(undefined)).toStrictEqual([])
+    })
+  })
+
+  describe("getFirstString", () => {
+    it("should return the string if passed a string", () => {
+      expect(getFirstString("Hello world!")).toBe("Hello world!")
+    })
+    it("should get the first string from an array", () => {
+      expect(getFirstString(["Hello", "World"])).toBe("Hello")
+    })
+    it("should return undefined if the value isn't an array or a string", () => {
+      expect(getFirstString({ name: "Coder" })).toBe(undefined)
     })
   })
 })

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,5 +1,16 @@
-import { logger as l } from "@coder/logger"
-import { arrayify, getFirstString, normalize, plural, resolveBase, split, trimSlashes } from "../src/common/util"
+// Note: we need to import logger from the root
+// because this is the logger used in logError in ../src/common/util
+import { logger } from "../node_modules/@coder/logger"
+import {
+  arrayify,
+  getFirstString,
+  logError,
+  normalize,
+  plural,
+  resolveBase,
+  split,
+  trimSlashes,
+} from "../src/common/util"
 
 type LocationLike = Pick<Location, "pathname" | "origin">
 
@@ -96,6 +107,7 @@ describe("util", () => {
     it("should return value it's already an array", () => {
       expect(arrayify(["hello", "world"])).toStrictEqual(["hello", "world"])
     })
+
     it("should wrap the value in an array if not an array", () => {
       expect(
         arrayify({
@@ -104,6 +116,7 @@ describe("util", () => {
         }),
       ).toStrictEqual([{ name: "Coder", version: "3.8" }])
     })
+
     it("should return an empty array if the value is undefined", () => {
       expect(arrayify(undefined)).toStrictEqual([])
     })
@@ -113,11 +126,46 @@ describe("util", () => {
     it("should return the string if passed a string", () => {
       expect(getFirstString("Hello world!")).toBe("Hello world!")
     })
+
     it("should get the first string from an array", () => {
       expect(getFirstString(["Hello", "World"])).toBe("Hello")
     })
+
     it("should return undefined if the value isn't an array or a string", () => {
       expect(getFirstString({ name: "Coder" })).toBe(undefined)
+    })
+  })
+
+  describe("logError", () => {
+    let spy: jest.SpyInstance
+
+    beforeEach(() => {
+      spy = jest.spyOn(logger, "error")
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    afterAll(() => {
+      jest.restoreAllMocks()
+    })
+
+    it("should log an error with the message and stack trace", () => {
+      const message = "You don't have access to that folder."
+      const error = new Error(message)
+
+      logError("ui", error)
+
+      expect(spy).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledWith(`ui: ${error.message} ${error.stack}`)
+    })
+
+    it("should log an error, even if not an instance of error", () => {
+      logError("api", "oh no")
+
+      expect(spy).toHaveBeenCalled()
+      expect(spy).toHaveBeenCalledWith("api: oh no")
     })
   })
 })

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -551,6 +551,15 @@
     jest-diff "^26.0.0"
     pretty-format "^26.0.0"
 
+"@types/jsdom@^16.2.6":
+  version "16.2.6"
+  resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.6.tgz#9ddf0521e49be5365797e690c3ba63148e562c29"
+  integrity sha512-yQA+HxknGtW9AkRTNyiSH3OKW5V+WzO8OPTdne99XwJkYC+KYxfNIcoJjeiSqP3V00PUUpFP6Myoo9wdIu78DQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/parse5" "*"
+    "@types/tough-cookie" "*"
+
 "@types/node-fetch@^2.5.8":
   version "2.5.8"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.8.tgz#e199c835d234c7eb0846f6618012e558544ee2fb"
@@ -568,6 +577,11 @@
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
   integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
+"@types/parse5@*":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.0.tgz#38590dc2c3cf5717154064e3ee9b6947ee21b299"
+  integrity sha512-oPwPSj4a1wu9rsXTEGIJz91ISU725t0BmSnUhb57sI+M8XEmvUop84lzuiYdq0Y5M6xLY8DBPg0C2xEQKLyvBA==
 
 "@types/prettier@^2.0.0":
   version "2.1.6"
@@ -593,6 +607,11 @@
   integrity sha512-Xt8TbEyZTnD5Xulw95GLMOkmjGICrOQyJ2jqgkSjAUR3mm7pAIzSR0NFBaMcwlzVvlpCjNwbATcWWwjNiZiFrQ==
   dependencies:
     "@types/superagent" "*"
+
+"@types/tough-cookie@*":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
+  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/yargs-parser@*":
   version "20.2.0"


### PR DESCRIPTION
This PR adds several unit tests for the `src/common/util` functions.

## Screenshot

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/3806031/106932792-64320900-66d5-11eb-902e-c4a0af349a86.png">

It increases our code coverage (Lines) from 46.88% to 49.53% (↑ 2.65%)
🟩 100% coverage for `src/common/util`
<img width="506" alt="image" src="https://user-images.githubusercontent.com/3806031/106932756-58dedd80-66d5-11eb-8113-5adc3571e5c7.png">


## TODOS
- [x] write tests for `logError`
- [x] write tests for `getOptions`
- [x] write tests for `generateUuid`
- [x] update screenshot and percentage