### PR TITLE
docs: clarify Alpine install path in install.md

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 # Install
 
 - [Upgrading](#upgrading)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 # Install
 
 - [Upgrading](#upgrading)
@@ -126,6 +127,7 @@ We recommend installing with `yarn` or `npm` when:
 
 1. You aren't on `amd64` or `arm64`.
 2. If you're on Linux with glibc < v2.17 or glibcxx < v3.4.18
+3. You're running Alpine Linux. See [#1430](https://github.com/cdr/code-server/issues/1430#issuecomment-629883198)
 
 **note:** Installing via `yarn` or `npm` builds native modules on install and so requires C dependencies.
 See [./npm.md](./npm.md) for installing these dependencies.

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # code-server's automatic install script.
-# See https://github.com/cdr/code-server/blob/master/docs/install.md
+# See https://github.com/cdr/code-server/blob/v3.8.1/docs/install.md
 
 usage() {
   arg0="$0"
@@ -67,7 +67,7 @@ Usage:
 
 It will cache all downloaded assets into ~/.cache/code-server
 
-More installation docs are at https://github.com/cdr/code-server/blob/master/docs/install.md
+More installation docs are at https://github.com/cdr/code-server/blob/v3.8.1/docs/install.md
 EOF
 }
 
@@ -419,7 +419,7 @@ install_npm() {
   echoh
   echoerr "Please install npm or yarn to install code-server!"
   echoerr "You will need at least node v12 and a few C dependencies."
-  echoerr "See the docs https://github.com/cdr/code-server/blob/master/docs/install.md#yarn-npm"
+  echoerr "See the docs https://github.com/cdr/code-server/blob/v3.8.1/docs/install.md#yarn-npm"
   exit 1
 }
 

--- a/install.sh
+++ b/install.sh
@@ -419,7 +419,7 @@ install_npm() {
   echoh
   echoerr "Please install npm or yarn to install code-server!"
   echoerr "You will need at least node v12 and a few C dependencies."
-  echoerr "See the docs https://github.com/cdr/code-server#yarn-npm"
+  echoerr "See the docs https://github.com/cdr/code-server/blob/master/docs/install.md#yarn-npm"
   exit 1
 }
 


### PR DESCRIPTION
From install.md, the path to install code-server on Linux Alpine is unclear.

#1430 recommends using the npm script, since the install script doesn't work.