### PR TITLE
feat(testing): add unit tests for src/common/http

### DIFF
--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,0 +1,35 @@
+import { HttpCode, HttpError } from "../src/common/http"
+
+describe("http", () => {
+  describe("HttpCode", () => {
+    it("should return the correct HTTP codes", () => {
+      expect(HttpCode.Ok).toBe(200)
+      expect(HttpCode.Redirect).toBe(302)
+      expect(HttpCode.NotFound).toBe(404)
+      expect(HttpCode.BadRequest).toBe(400)
+      expect(HttpCode.Unauthorized).toBe(401)
+      expect(HttpCode.LargePayload).toBe(413)
+      expect(HttpCode.ServerError).toBe(500)
+    })
+  })
+
+  describe("HttpError", () => {
+    it("should work as expected", () => {
+      const message = "Bad request from client"
+      const httpError = new HttpError(message, HttpCode.BadRequest)
+
+      expect(httpError.message).toBe(message)
+      expect(httpError.status).toBe(400)
+      expect(httpError.details).toBeUndefined()
+    })
+    it("should have details if provided", () => {
+      const details = {
+        message: "User needs to be signed-in in order to perform action",
+      }
+      const message = "Unauthorized"
+      const httpError = new HttpError(message, HttpCode.BadRequest, details)
+
+      expect(httpError.details).toStrictEqual(details)
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a few tests for `src/common/http`. Note: intentionally selected `add-unit-tests-constants` as the base since I branched off it.

## Screenshot

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/3806031/107406579-d33ca280-6ac5-11eb-90f9-063ad58066ee.png">

It increases our code coverage (Lines) from 49.83% to 50.09% (↑ 0.0.26%).
🟩 100% Line coverage (last 100) for `src/node/http.ts`
<img width="548" alt="image" src="https://user-images.githubusercontent.com/3806031/107406729-f9fad900-6ac5-11eb-91c3-fd1208343971.png">


