### PR TITLE
release: v3.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # code-server &middot; [!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
 
-![Lines](https://img.shields.io/badge/Coverage-40.7%25-green.svg)
+![Lines](https://img.shields.io/badge/Coverage-50.08%25-green.svg)
 
 Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and access it in the browser.
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -28,6 +28,7 @@ Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) 
 3. Run `yarn release:github-draft` to create a GitHub draft release from the template with
    the updated version.
    1. Summarize the major changes in the release notes and link to the relevant issues.
+   2. Change the @ to target the version branch. Example: `v3.9.0 @ Target: v3.9.0`
 4. Wait for the artifacts in step 2 to build.
 5. Run `yarn release:github-assets` to download the `release-packages` artifact.
    - It will upload them to the draft release.

--- a/ci/README.md
+++ b/ci/README.md
@@ -49,8 +49,9 @@ Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) 
 
 Currently, we run a command to manually generate the code coverage shield. Follow these steps:
 
-1. Run `yarn badges`
-2. Go into the README and change the color from `red` to `green` in this line:
+1. Run `yarn test` and make sure all the tests are passing
+2. Run `yarn badges`
+3. Go into the README and change the color from `red` to `green` in this line:
 
 ```
 ![Lines](https://img.shields.io/badge/Coverage-46.71%25-red.svg)

--- a/ci/build/release-github-draft.sh
+++ b/ci/build/release-github-draft.sh
@@ -26,6 +26,13 @@ installations.
 ## Bug Fixes
   - ⭐ Summarize bug fixes here with references to issues
 
+## Documentation
+  - ⭐ Summarize doc changes here with references to issues
+
+## Development
+  - ⭐ Summarize development/testing changes here with references to issues
+
+
 Cheers! 🍻
 EOF
 }

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.8.1
+appVersion: 3.9.0

--- a/ci/helm-chart/README.md
+++ b/ci/helm-chart/README.md
@@ -1,6 +1,6 @@
 # code-server
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.8.1](https://img.shields.io/badge/AppVersion-3.8.1-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.0](https://img.shields.io/badge/AppVersion-3.9.0-informational?style=flat-square)
 
 [code-server](https://github.com/cdr/code-server) code-server is VS Code running
 on a remote server, accessible through the browser.
@@ -72,7 +72,7 @@ and their default values.
 | hostnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"codercom/code-server"` |  |
-| image.tag | string | `"3.8.1"` |  |
+| image.tag | string | `"3.9.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '3.8.1'
+  tag: '3.9.0'
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,19 +2,18 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 # Install
 
-- [Install](#install)
-  - [Upgrading](#upgrading)
-  - [install.sh](#installsh)
-    - [Flags](#flags)
-    - [Detection Reference](#detection-reference)
-  - [Debian, Ubuntu](#debian-ubuntu)
-  - [Fedora, CentOS, RHEL, SUSE](#fedora-centos-rhel-suse)
-  - [Arch Linux](#arch-linux)
-  - [yarn, npm](#yarn-npm)
-  - [macOS](#macos)
-  - [Standalone Releases](#standalone-releases)
-  - [Docker](#docker)
-  - [helm](#helm)
+- [Upgrading](#upgrading)
+- [install.sh](#installsh)
+  - [Flags](#flags)
+  - [Detection Reference](#detection-reference)
+- [Debian, Ubuntu](#debian-ubuntu)
+- [Fedora, CentOS, RHEL, SUSE](#fedora-centos-rhel-suse)
+- [Arch Linux](#arch-linux)
+- [yarn, npm](#yarn-npm)
+- [macOS](#macos)
+- [Standalone Releases](#standalone-releases)
+- [Docker](#docker)
+- [helm](#helm)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -2,18 +2,19 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 # Install
 
-- [Upgrading](#upgrading)
-- [install.sh](#installsh)
-  - [Flags](#flags)
-  - [Detection Reference](#detection-reference)
-- [Debian, Ubuntu](#debian-ubuntu)
-- [Fedora, CentOS, RHEL, SUSE](#fedora-centos-rhel-suse)
-- [Arch Linux](#arch-linux)
-- [yarn, npm](#yarn-npm)
-- [macOS](#macos)
-- [Standalone Releases](#standalone-releases)
-- [Docker](#docker)
-- [helm](#helm)
+- [Install](#install)
+  - [Upgrading](#upgrading)
+  - [install.sh](#installsh)
+    - [Flags](#flags)
+    - [Detection Reference](#detection-reference)
+  - [Debian, Ubuntu](#debian-ubuntu)
+  - [Fedora, CentOS, RHEL, SUSE](#fedora-centos-rhel-suse)
+  - [Arch Linux](#arch-linux)
+  - [yarn, npm](#yarn-npm)
+  - [macOS](#macos)
+  - [Standalone Releases](#standalone-releases)
+  - [Docker](#docker)
+  - [helm](#helm)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -87,8 +88,8 @@ commands presented in the rest of this document.
 ## Debian, Ubuntu
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.8.1/code-server_3.8.1_amd64.deb
-sudo dpkg -i code-server_3.8.1_amd64.deb
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.9.0/code-server_3.9.0_amd64.deb
+sudo dpkg -i code-server_3.9.0_amd64.deb
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -96,8 +97,8 @@ sudo systemctl enable --now code-server@$USER
 ## Fedora, CentOS, RHEL, SUSE
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.8.1/code-server-3.8.1-amd64.rpm
-sudo rpm -i code-server-3.8.1-amd64.rpm
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.9.0/code-server-3.9.0-amd64.rpm
+sudo rpm -i code-server-3.9.0-amd64.rpm
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -167,10 +168,10 @@ Here is an example script for installing and using a standalone `code-server` re
 
 ```bash
 mkdir -p ~/.local/lib ~/.local/bin
-curl -fL https://github.com/cdr/code-server/releases/download/v3.8.1/code-server-3.8.1-linux-amd64.tar.gz \
+curl -fL https://github.com/cdr/code-server/releases/download/v3.9.0/code-server-3.9.0-linux-amd64.tar.gz \
   | tar -C ~/.local/lib -xz
-mv ~/.local/lib/code-server-3.8.1-linux-amd64 ~/.local/lib/code-server-3.8.1
-ln -s ~/.local/lib/code-server-3.8.1/bin/code-server ~/.local/bin/code-server
+mv ~/.local/lib/code-server-3.9.0-linux-amd64 ~/.local/lib/code-server-3.9.0
+ln -s ~/.local/lib/code-server-3.9.0/bin/code-server ~/.local/bin/code-server
 PATH="~/.local/bin:$PATH"
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # code-server's automatic install script.
-# See https://github.com/cdr/code-server/blob/v3.8.1/docs/install.md
+# See https://github.com/cdr/code-server/blob/v3.9.0/docs/install.md
 
 usage() {
   arg0="$0"
@@ -67,7 +67,7 @@ Usage:
 
 It will cache all downloaded assets into ~/.cache/code-server
 
-More installation docs are at https://github.com/cdr/code-server/blob/v3.8.1/docs/install.md
+More installation docs are at https://github.com/cdr/code-server/blob/v3.9.0/docs/install.md
 EOF
 }
 
@@ -419,7 +419,7 @@ install_npm() {
   echoh
   echoerr "Please install npm or yarn to install code-server!"
   echoerr "You will need at least node v12 and a few C dependencies."
-  echoerr "See the docs https://github.com/cdr/code-server/blob/v3.8.1/docs/install.md#yarn-npm"
+  echoerr "See the docs https://github.com/cdr/code-server/blob/v3.9.0/docs/install.md#yarn-npm"
   exit 1
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/cdr/code-server",
   "bugs": {


### PR DESCRIPTION
This PR is to generate a new release of `code-server` at v3.8.1

![2021-02-12 17 12 48](https://user-images.githubusercontent.com/3806031/107835109-a1416f80-6d55-11eb-9db8-4b0b22ec580c.gif)

And the Vim extension is working!!

## TODOs
- [ ] @code-asher to update the AUR package
- [x] upload assets to draft release
- [x] test locally
- [x] double-check github release tag is the commit with artifacts
- [x] publish release 
- [ ] merge PR
- [x] update the homebrew package https://github.com/Homebrew/homebrew-core/pull/71018
