### PR TITLE
Fix terminal process leak when closing the window.

### DIFF
--- a/lib/vscode/src/vs/server/node/channel.ts
+++ b/lib/vscode/src/vs/server/node/channel.ts
@@ -575,17 +575,17 @@ class Terminal {
 		// type: 'orphan?';
 	}
 
-	public dispose() {
+	public async dispose() {
 		logger.debug('Terminal disposing', field('id', this.id));
 		this._onEvent.dispose();
 		this.bufferer.dispose();
-		this.process.dispose();
-		this.process.shutdown(true);
+		await this.process.shutdown(true);
+		this.process.dispose();		
 		this._onDispose.fire();
 		this._onDispose.dispose();
 	}
 
-	public shutdown(immediate: boolean): void {
+	public shutdown(immediate: boolean): Promise<void> {
 		return this.process.shutdown(immediate);
 	}
 

--- a/lib/vscode/src/vs/server/node/channel.ts
+++ b/lib/vscode/src/vs/server/node/channel.ts
@@ -580,7 +580,7 @@ class Terminal {
 		this._onEvent.dispose();
 		this.bufferer.dispose();
 		await this.process.shutdown(true);
-		this.process.dispose();		
+		this.process.dispose();
 		this._onDispose.fire();
 		this._onDispose.dispose();
 	}

--- a/lib/vscode/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
+++ b/lib/vscode/src/vs/workbench/contrib/terminal/node/terminalProcess.ts
@@ -245,9 +245,9 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		this._onProcessTitleChanged.fire(this._currentTitle);
 	}
 
-	public shutdown(immediate: boolean): void {
+	public async shutdown(immediate: boolean): Promise<void> {
 		if (immediate) {
-			this._kill();
+			await this._kill();
 		} else {
 			this._queueProcessExit();
 		}


### PR DESCRIPTION
Calling `this.process.dispose();` before `this.process.shutdown(true);` sets a flag `_isDisposed` to true.
This causes the `_kill()` procedure to exit early essentially making `this.process.shutdown(true)` a no op.

It's necessary to await on the shutdown because _kill() is an async function. Otherwise  `_isDisposed` will be set to true before actually killing the process regardless of the call order of `dispose` and `shutdown`.

Impact: Closing the session in the browser should now kill long running processes such as filesystem watchers or services started in the terminal.