### PR TITLE
docs(install): add Azure and Heroku

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,6 +4,7 @@
 
 - [Questions?](#questions)
 - [iPad Status?](#ipad-status)
+- [Community Projects (awesome-code-server)](#awesome-code-server)
 - [How can I reuse my VS Code configuration?](#how-can-i-reuse-my-vs-code-configuration)
 - [Differences compared to VS Code?](#differences-compared-to-vs-code)
 - [How can I request a missing extension?](#how-can-i-request-a-missing-extension)
@@ -41,6 +42,10 @@ Please file all questions and support requests at https://github.com/cdr/code-se
 ## iPad Status?
 
 Please see [./ipad.md](./ipad.md).
+
+## Community projects (awesome-code-server)
+
+Visit the [awesome-code-server](https://github.com/cdr/awesome-code-server) repository to view community projects and guides with code-server! Feel free to add your own!
 
 ## How can I reuse my VS Code configuration?
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,5 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 # Install
 
 - [Upgrading](#upgrading)

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 # Install
 
 - [Upgrading](#upgrading)
@@ -14,6 +15,7 @@
 - [Standalone Releases](#standalone-releases)
 - [Docker](#docker)
 - [helm](#helm)
+- [App Engines (Azure, Heroku)](#app-engines)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -205,3 +207,10 @@ https://hub.docker.com/r/linuxserver/code-server
 ## helm
 
 See [the chart](../ci/helm-chart).
+
+## App Engines (Azure, Heroku)
+
+These community images are optimized for use with popular app engines. They use the latest official [Docker](#docker) image, so they will always be up to date.
+
+- [code-server-heroku](https://github.com/bpmct/code-server-heroku)
+- [code-server-azure](https://github.com/bpmct/code-server-azure)


### PR DESCRIPTION
Adds an initial section in install.md for deploying code-server to app engines.

closes #2711,  #2686 