### PR TITLE
fix(vscode): update link in extensionsViewlet

### DIFF
--- a/lib/vscode/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/lib/vscode/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -476,7 +476,7 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer implements IE
 				<p style="margin-top: 0; margin-bottom: 4px">
 				These extensions are not official. Find additional open-source extensions
 				<a style="color: ${linkColor}" href="https://open-vsx.org/" target="_blank">here</a>.
-				See <a style="color: ${linkColor}" href="https://github.com/cdr/code-server/blob/master/doc/FAQ.md#differences-compared-to-vs-code" target="_blank">docs</a>.
+				See <a style="color: ${linkColor}" href="https://github.com/cdr/code-server/blob/master/docs/FAQ.md#differences-compared-to-vs-code" target="_blank">docs</a>.
 				</p>
 				</div>
 						`;

--- a/lib/vscode/src/vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page.ts
+++ b/lib/vscode/src/vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page.ts
@@ -38,9 +38,9 @@ export default () => `
 						<li><a href="https://github.com/cdr/code-server">GitHub Repository</a></li>
 						<li><a href="https://github.com/cdr/code-server/releases/tag/v${product.codeServerVersion}">Release Notes</a></li>
 						<li><a href="https://github.com/cdr/code-server/issues">Issue Tracker</a></li>
-						<li><a href="https://github.com/cdr/code-server/blob/master/doc/FAQ.md">FAQ</a></li>
-						<li><a href="https://github.com/cdr/code-server/blob/master/doc/guide.md">Setup Guide</a></li>
-						<li><a href="https://github.com/cdr/code-server/tree/master/doc">Docs</a></li>
+						<li><a href="https://github.com/cdr/code-server/blob/master/docs/FAQ.md">FAQ</a></li>
+						<li><a href="https://github.com/cdr/code-server/blob/master/docs/guide.md">Setup Guide</a></li>
+						<li><a href="https://github.com/cdr/code-server/tree/master/docs">Docs</a></li>
 						<li><a href="https://github.com/cdr/code-server/discussions">Discussions</a></li>
 						<li><a href="https://cdr.co/join-community">Slack</a></li>
 					</ul>


### PR DESCRIPTION
When we moved the docs from `/doc` to `/docs` in #2669, I forgot to update this link.

This is the little helper shown in the Extensions panel, which links to our docs. This also fixes the links in the Welcome page.

Thank you to @kylecarbs @JammSpread @MarkAYoder for reporting these issues!