### PR TITLE
docs(ci): update release steps with homebrew bump

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -43,8 +43,9 @@ Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) 
 9. Update the AUR package.
    - Instructions on updating the AUR package are at [cdr/code-server-aur](https://github.com/cdr/code-server-aur).
 10. Wait for the npm package to be published.
-11. Update the homebrew package.
-    - Send a pull request to [homebrew-core](https://github.com/Homebrew/homebrew-core) with the URL in the [formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/code-server.rb) updated.
+11. Update the [homebrew package](https://github.com/Homebrew/homebrew-core/blob/master/Formula/code-server.rb).
+    1. Install [homebrew](https://brew.sh/)
+    2. Run `brew bump-formula-pr --version=3.8.1 code-server` and update the version accordingly. This will bump the version and open a PR. Note: this will only work once the version is published on npm.
 
 ## Updating Code Coverage in README
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -4,7 +4,7 @@
 
 - [Questions?](#questions)
 - [iPad Status?](#ipad-status)
-- [Community projects (awesome-code-server)](#community-projects-awesome-code-server)
+- [Community Projects (awesome-code-server)](#community-projects-awesome-code-server)
 - [How can I reuse my VS Code configuration?](#how-can-i-reuse-my-vs-code-configuration)
 - [Differences compared to VS Code?](#differences-compared-to-vs-code)
 - [How can I request a missing extension?](#how-can-i-request-a-missing-extension)
@@ -43,7 +43,7 @@ Please file all questions and support requests at https://github.com/cdr/code-se
 
 Please see [./ipad.md](./ipad.md).
 
-## Community projects (awesome-code-server)
+## Community Projects (awesome-code-server)
 
 Visit the [awesome-code-server](https://github.com/cdr/awesome-code-server) repository to view community projects and guides with code-server! Feel free to add your own!
 


### PR DESCRIPTION
This PR updates the `ci` docs with steps for updating the homebrew package more easily using `brew bump-forumla-pr`.

TODOS
- [x] address feedback
