### PR TITLE
fix: Responsive Sign In Page

### DIFF
--- a/src/browser/pages/login.css
+++ b/src/browser/pages/login.css
@@ -1,4 +1,6 @@
 body {
+  min-height: 568px;
+  min-width: 320px;
   overflow: auto;
 }
 
@@ -13,6 +15,12 @@ body {
   display: flex;
   flex-direction: row;
   width: 100%;
+}
+
+@media (max-width: 600px) {
+  .login-form > .field {
+    flex-direction: column;
+  }
 }
 
 .login-form > .error {
@@ -36,6 +44,13 @@ body {
 
 .login-form > .field > .submit {
   margin-left: 20px;
+}
+
+@media (max-width: 600px) {
+  .login-form > .field > .submit {
+    margin-left: 0px;
+    margin-top: 16px;
+  }
 }
 
 input {


### PR DESCRIPTION
Resolves: #2769 

## Summary

Adds media queries and min body dimensions to the Sign In Page

## Details

- A typical "sm" breakpoint of 600px is used to toggle the sign in card to a column
- The min page dimensions are that of an iphone 5

## Demo

![demo](https://user-images.githubusercontent.com/11184711/109181999-28c5b000-7752-11eb-9602-f4098bc6e30f.gif)
