### PR TITLE
fix(ci): add step to remove docker images on linux-arm64 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,9 +105,7 @@ jobs:
           name: release-packages
           path: ./release-packages
       - name: Remove docker images
-        run: |
-          docker rm $(docker ps -aq)
-          docker rmi $(docker images -q)
+        run: docker system prune -af
 
   macos-amd64:
     needs: release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,8 +49,7 @@ jobs:
           name: test-videos
           path: ./test/videos
       - name: Remove release packages and test artifacts
-          run: |
-            rm -rf ./release-packages ./test/videos
+        run: rm -rf ./release-packages ./test/videos
 
   release:
     runs-on: ubuntu-latest
@@ -105,6 +104,10 @@ jobs:
         with:
           name: release-packages
           path: ./release-packages
+      - name: Remove docker images
+        run: |
+          docker rm $(docker ps -aq)
+          docker rmi $(docker images -q)
 
   macos-amd64:
     needs: release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,9 @@ jobs:
         with:
           name: test-videos
           path: ./test/videos
+      - name: Remove release packages and test artifacts
+          run: |
+            rm -rf ./release-packages ./test/videos
 
   release:
     runs-on: ubuntu-latest

--- a/ci/build/test-standalone-release.sh
+++ b/ci/build/test-standalone-release.sh
@@ -12,11 +12,12 @@ main() {
 
   echo "Testing standalone release."
 
-  ./release-standalone/bin/code-server --extensions-dir "$EXTENSIONS_DIR" --install-extension ms-python.python
+  # Note: using a basic theme extension because it doesn't update often and is more reliable for testing
+  ./release-standalone/bin/code-server --extensions-dir "$EXTENSIONS_DIR" --install-extension wesbos.theme-cobalt2
   local installed_extensions
   installed_extensions="$(./release-standalone/bin/code-server --extensions-dir "$EXTENSIONS_DIR" --list-extensions 2>&1)"
-  # We use grep as ms-python.python may have dependency extensions that change.
-  if ! echo "$installed_extensions" | grep -q "ms-python.python"; then
+  # We use grep as wesbos.theme-cobalt2 may have dependency extensions that change.
+  if ! echo "$installed_extensions" | grep -q "wesbos.theme-cobalt2"; then
     echo "Unexpected output from listing extensions:"
     echo "$installed_extensions"
     exit 1


### PR DESCRIPTION
This PR fixes #2480 .

- add step to remove docker images on `linux-arm64` ci job (thanks to @code-asher for the tip, @vapurrmaid for the refactor!)
- add step to remove release-packages and test/videos on the `test` job 
- changes the extension used in `test:standalone-release`

I suggest changing the extension away from the Python because it's notorious for breaking in code-server. A theme extension changes less frequently and is much more reliable for testing.