### PR TITLE
docs(README, ci): add docs shield with link to version docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # code-server &middot; [!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
 
 ![Lines](https://img.shields.io/badge/Coverage-50.08%25-green.svg)
+[![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.9.0/docs)
 
 Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and access it in the browser.
 

--- a/ci/README.md
+++ b/ci/README.md
@@ -23,6 +23,7 @@ Make sure you have `$GITHUB_TOKEN` set and [hub](https://github.com/github/hub) 
         changed. Replace the numbers as needed.
         - You can install `rg` or `ripgrep` on macOS [here](https://formulae.brew.sh/formula/ripgrep).
    4. Update the code coverage badge (see [here](#updating-code-coverage-in-readme) for instructions)
+   5. Update the docs badge in [./README.md](../README.md)
 2. GitHub actions will generate the `npm-package`, `release-packages` and `release-images` artifacts.
    1. You do not have to wait for these.
 3. Run `yarn release:github-draft` to create a GitHub draft release from the template with


### PR DESCRIPTION
This PR:
- adds a shield linking to the docs
- updates the release steps in the `ci/README`

## Screenshot

<img width="2032" alt="image" src="https://user-images.githubusercontent.com/3806031/109725148-f19a3900-7b6d-11eb-82e4-3bcb3c63a501.png">
