### PR TITLE
chore: use dependabot to manage dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,8 @@ updates:
     - "jawnsy"
   ignore:
     # GitHub always delivers the latest versions for each major
-    # release tag, so ignore minor version tags
-    - dependency-name: "actions/cache"
-      versions:
-        - 2.x
-    - dependency-name: "actions/checkout"
-      versions:
-        - 2.x
+    # release tag, so handle updates manually
+    - dependency-name: "actions/*"
 
 - package-ecosystem: "npm"
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,25 @@
 version: 2
 updates:
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-    time: "11:00"
-  assignees:
-    - "jawnsy"
-  reviewers:
-    - "jawnsy"
-  ignore:
-    # GitHub always delivers the latest versions for each major
-    # release tag, so handle updates manually
-    - dependency-name: "actions/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "11:00"
+    assignees:
+      - "jawnsy"
+    reviewers:
+      - "jawnsy"
+    ignore:
+      # GitHub always delivers the latest versions for each major
+      # release tag, so handle updates manually
+      - dependency-name: "actions/*"
 
-- package-ecosystem: "npm"
-  directory: "/"
-  schedule:
-    interval: "daily"
-    time: "11:00"
-  assignees:
-    - "jawnsy"
-  reviewers:
-    - "jawnsy"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "11:00"
+    assignees:
+      - "jawnsy"
+    reviewers:
+      - "jawnsy"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,26 @@ updates:
   schedule:
     interval: "daily"
     time: "11:00"
-  open-pull-requests-limit: 10
   assignees:
-    - "dependabot"
+    - "jawnsy"
+  reviewers:
+    - "jawnsy"
+  ignore:
+    # GitHub always delivers the latest versions for each major
+    # release tag, so ignore minor version tags
+    - dependency-name: "actions/cache"
+      versions:
+        - 2.x
+    - dependency-name: "actions/checkout"
+      versions:
+        - 2.x
 
-- package-ecosystem: npm
+- package-ecosystem: "npm"
   directory: "/"
   schedule:
-    interval: daily
+    interval: "daily"
     time: "11:00"
-  open-pull-requests-limit: 10
   assignees:
-    - "dependabot"
+    - "jawnsy"
+  reviewers:
+    - "jawnsy"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+    time: "11:00"
+  open-pull-requests-limit: 10
+  assignees:
+    - "dependabot"
+
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "11:00"
+  open-pull-requests-limit: 10
+  assignees:
+    - "dependabot"


### PR DESCRIPTION
Use dependabot to manage the dependencies defined in package.json and
GitHub Actions workflows, so that we can proactively update versions.

Outdated versions of third-party dependencies frequently have known
security vulnerabilities with CVEs.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the master branch!
-->
