### PR TITLE
add instructions for deploying to a cloud provider 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ You can use whatever linux distribution floats your boat but in our [guide](./do
 
 ## Getting Started
 
-There are two ways to get started:
+There are three ways you can get started:
 
 1. Using the [install script](./install.sh), which automates most of the process. The script uses the system package manager (if possible)
 2. Manually installing code-server; see [Installation](./docs/install.md) for instructions applicable to most use cases
+3. Use our one-click buttons and guides to [deploy code-server to a popular cloud provider](https://github.com/cdr/deploy-code-server)
 
 If you choose to use the install script, you can preview what occurs during the install process:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ There are three ways you can get started:
 
 1. Using the [install script](./install.sh), which automates most of the process. The script uses the system package manager (if possible)
 2. Manually installing code-server; see [Installation](./docs/install.md) for instructions applicable to most use cases
-3. Use our one-click buttons and guides to [deploy code-server to a popular cloud provider](https://github.com/cdr/deploy-code-server)
+3. Use our one-click buttons and guides to [deploy code-server to a popular cloud provider](https://github.com/cdr/deploy-code-server) ⚡
 
 If you choose to use the install script, you can preview what occurs during the install process:
 
@@ -46,7 +46,7 @@ When done, the install script prints out instructions for running and starting c
 
 We also have an in-depth [setup and configuration](./docs/guide.md) guide.
 
-### Cloud Program ☁️
+### code-server --link
 
 We're working on a cloud platform that makes deploying and managing code-server easier.
 Consider running code-server with the beta flag `--link` if you don't want to worry about

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@
 - [Standalone Releases](#standalone-releases)
 - [Docker](#docker)
 - [helm](#helm)
-- [App Engines (Azure, Heroku)](#app-engines-azure-heroku)
+- [Cloud Providers](#cloud-providers)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -207,9 +207,8 @@ https://hub.docker.com/r/linuxserver/code-server
 
 See [the chart](../ci/helm-chart).
 
-## App Engines (Azure, Heroku)
+## Cloud Providers
 
-These community images are optimized for use with popular app engines. They use the latest official [Docker](#docker) image, so they will always be up to date.
+We maintain one-click apps and install scripts for different cloud providers such as DigitalOcean, Railway, Heroku, Azure, etc. Check out the repository:
 
-- [code-server-heroku](https://github.com/bpmct/code-server-heroku)
-- [code-server-azure](https://github.com/bpmct/code-server-azure)
+https://github.com/cdr/deploy-code-server


### PR DESCRIPTION
I have been working on the [cdr/deploy-code-server](https://github.com/cdr/deploy-code-server) project which includes one-click buttons and guides to deploy code-server to a cloud provider, such as Linode or Heroku.

![deploy-code-server repo](https://user-images.githubusercontent.com/22407953/110383876-f017b780-802a-11eb-81e5-dafd92f76b58.png)

@jsjoeio and I have been discussing including parts of this in the code-server repo, as it is a great way to get started using it. It is only a few steps to get an environment that can be accessed from anywhere!

However, I think that we cannot simply add all of the docs and guides to this repo. Here's why:

- Certain providers (such as Heroku and Railway) require that some info lives in the base directory of the repository, such as the [heroku.yml](https://github.com/cdr/deploy-code-server/blob/main/heroku.yml) flle. This would mess up code-server's folder structure.
- Since the latest code-server version is the default branch, users will not see updates for deploy options until the next version. We may add support for other cloud providers or add fixes before then
- Providers like Railway and Heroku involve the user "forking" the repo to their account so they can modify their environment. It wouldn't be ideal for the user to fork the whole code-server codebase 

However, it may be valuable to add links to deploy to certain providers instead of linking to the entire project. We could include a partial table to README or install.md to include this info?

I think the source-of-truth for the docs and guides should live on the separate [deploy-code-server](https://github.com/cdr/deploy-code-server) repo though

Currently, our [install.md](https://github.com/cdr/code-server/blob/main/docs/install.md#app-engines-azure-heroku) currently has (now outdated) instructions for deploying. We could also add there.