### PR TITLE
docs(npm): update node requirements

### DIFF
--- a/docs/npm.md
+++ b/docs/npm.md
@@ -2,18 +2,24 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 # npm Install Requirements
 
-- [Ubuntu, Debian](#ubuntu-debian)
-- [Fedora, CentOS, RHEL](#fedora-centos-rhel)
-- [Alpine](#alpine)
-- [macOS](#macos)
-- [FreeBSD](#freebsd)
+- [npm Install Requirements](#npm-install-requirements)
+  - [Ubuntu, Debian](#ubuntu-debian)
+  - [Fedora, CentOS, RHEL](#fedora-centos-rhel)
+  - [Alpine](#alpine)
+  - [macOS](#macos)
+  - [FreeBSD](#freebsd)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-If you're installing the npm module you'll need certain dependencies to build
-the native modules used by VS Code.
+If you're installing the npm module you'll need certain dependencies to build the native modules used by VS Code.
 
-You also need at least node v12 installed. See [#1633](https://github.com/cdr/code-server/issues/1633).
+- Node.js: version `>= 12`, `<= 14`
+
+_Note: the Node.js version requirements are based on the VS Code Node.js requirements. See [here](https://github.com/microsoft/vscode/wiki/How-to-Contribute#prerequisites)._
+
+Related:
+
+- [#1633](https://github.com/cdr/code-server/issues/1633)
 
 ## Ubuntu, Debian
 

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -2,12 +2,11 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 # npm Install Requirements
 
-- [npm Install Requirements](#npm-install-requirements)
-  - [Ubuntu, Debian](#ubuntu-debian)
-  - [Fedora, CentOS, RHEL](#fedora-centos-rhel)
-  - [Alpine](#alpine)
-  - [macOS](#macos)
-  - [FreeBSD](#freebsd)
+- [Ubuntu, Debian](#ubuntu-debian)
+- [Fedora, CentOS, RHEL](#fedora-centos-rhel)
+- [Alpine](#alpine)
+- [macOS](#macos)
+- [FreeBSD](#freebsd)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "browser-ide"
   ],
   "engines": {
-    "node": ">= 12"
+    "node": ">= 12 <= 14"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
This PR fixes #2745 by adding extra information regarding Node.js requirements.

TODOS  
- [x] open separate issue for pre-install script that checks node version https://github.com/cdr/code-server/issues/2807
- [x] ~verify that v10 node works with code-server~  Couldn't get v10 Node to play nicely with code-server.
- [x] verify that v14 node works with code-server
- [x] issues with v15 as well
- [x] update docs

How I tested versions of node:
1. `nvm install 14`
2. `rm -rf node_modules`
3. `yarn`
4. `cd lib/vscode && npm rebuild`
5. `yarn watch`
6.  Navigate to localhost:8080 and see if code-server works