### PR TITLE
dev(update-vscode.sh): get latest vscode version and force commit files

### DIFF
--- a/ci/dev/update-vscode.sh
+++ b/ci/dev/update-vscode.sh
@@ -114,7 +114,7 @@ main() {
   # Hence why we do this after the subtree update.
   echo "Opening a draft PR on GitHub"
   # To read about these flags, visit the docs: https://cli.github.com/manual/gh_pr_create
-  gh pr create --base master --title "feat(vscode): update to version $VSCODE_EXACT_VERSION" --body "$PR_BODY" --reviewer @cdr/code-server-reviewers --repo cdr/code-server --draft
+  gh pr create --base main --title "feat(vscode): update to version $VSCODE_EXACT_VERSION" --body "$PR_BODY" --reviewer @cdr/code-server-reviewers --repo cdr/code-server --draft
 }
 
 main "$@"

--- a/ci/dev/update-vscode.sh
+++ b/ci/dev/update-vscode.sh
@@ -85,7 +85,9 @@ main() {
   if [[ -z $(git ls-remote --heads origin "$CURRENT_BRANCH") ]]; then
     echo "Doesn't look like you've pushed this branch to remote"
     echo -e "Pushing now using: git push origin $CURRENT_BRANCH\n"
-    git push origin "$CURRENT_BRANCH"
+    # Note: we need to set upstream as well or the gh pr create step will fail
+    # See: https://github.com/cli/cli/issues/575
+    git push -u origin "$CURRENT_BRANCH"
   fi
 
   echo "Going to try to update vscode for you..."

--- a/ci/dev/update-vscode.sh
+++ b/ci/dev/update-vscode.sh
@@ -104,7 +104,9 @@ main() {
   echo "Note: this is intentional"
   echo "If we don't do this, code review is impossible."
   echo -e "For more info, see docs: docs/CONTRIBUTING.md#updating-vs-code\n"
-  git add . && git commit -am "chore(vscode): update to $VSCODE_EXACT_VERSION"
+  # We need --no-verify to skip the husky pre-commit hook
+  # which fails because of the merge conflicts
+  git add . && git commit -am "chore(vscode): update to $VSCODE_EXACT_VERSION" --no-verify
 
   # Note: we can't open a draft PR unless their are changes.
   # Hence why we do this after the subtree update.


### PR DESCRIPTION
This PR modifies the `update-vscode.sh` script and greatly improves it:
- add more comments
- get latest version of vscode from `package.json`
- force commit conflicted files
- add more detailed PR message in draft PR

Fixes #2787
