### PR TITLE
chore: run builds on pull requests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,12 +1,18 @@
 name: ci
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Run ./ci/steps/fmt.sh
         uses: ./ci/images/debian10
         with:
@@ -15,7 +21,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Run ./ci/steps/lint.sh
         uses: ./ci/images/debian10
         with:
@@ -28,7 +34,7 @@ jobs:
       PASSWORD: e45432jklfdsab
       CODE_SERVER_ADDRESS: http://localhost:8080
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download release packages
         uses: actions/download-artifact@v2
         with:
@@ -55,7 +61,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Run ./ci/steps/release.sh
         uses: ./ci/images/debian10
         with:
@@ -70,7 +76,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download npm package
         uses: actions/download-artifact@v2
         with:
@@ -90,7 +96,7 @@ jobs:
     needs: release
     runs-on: ubuntu-arm64-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download npm package
         uses: actions/download-artifact@v2
         with:
@@ -111,8 +117,10 @@ jobs:
   macos-amd64:
     needs: release
     runs-on: macos-latest
+    # This job requires secrets, so can only run on the default branch
+    if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download npm package
         uses: actions/download-artifact@v2
         with:
@@ -133,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: linux-amd64
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download release package
         uses: actions/download-artifact@v2
         with:
@@ -153,7 +161,7 @@ jobs:
     runs-on: ubuntu-arm64-latest
     needs: linux-arm64
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Download release package
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
* Run builds when changes are pushed to the main branch, or for pull
  requests opened against the main branch. This is a subtle change
  in behavior because, previously, builds would've run on pushes to
  any branch, regardless if a pull request is open yet.
* Update to GitHub actions/checkout v2, which performs a shallow
  clone by default, which should speed up the build.

Closes: #2559 (:crossed_fingers:)

--

I believe that this should work, since only one job receives secrets according to the workflow definition (unless there's an administrative setting somewhere for global secrets passed using environment variables). However, I think the only way to be certain is to merge this and then open a pull request from a fork. If this breaks things or doesn't work correctly, we can always revert and try again.