### PR TITLE
fix: remove reviewers/assignees for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,6 @@ updates:
     schedule:
       interval: "daily"
       time: "11:00"
-    assignees:
-      - "jawnsy"
-    reviewers:
-      - "jawnsy"
     ignore:
       # GitHub always delivers the latest versions for each major
       # release tag, so handle updates manually
@@ -19,7 +15,3 @@ updates:
     schedule:
       interval: "daily"
       time: "11:00"
-    assignees:
-      - "jawnsy"
-    reviewers:
-      - "jawnsy"


### PR DESCRIPTION
This PR fixes #2898.

- @jawnsy is already a member @cdr/code-server-reviewers so he will see these PRs regardless but it also lets anyone else come in and review without them having to manually review him.
- no need to assign them all to @jawnsy - there are too many 😛