### PR TITLE
feat(lib/vscode): add log out to application menu

### DIFF
--- a/lib/vscode/src/vs/server/common/cookie.ts
+++ b/lib/vscode/src/vs/server/common/cookie.ts
@@ -1,3 +1,3 @@
 export enum Cookie {
-  Key = "key",
+  Key = 'key',
 }

--- a/lib/vscode/src/vs/server/common/cookie.ts
+++ b/lib/vscode/src/vs/server/common/cookie.ts
@@ -1,0 +1,3 @@
+export enum Cookie {
+  Key = "key",
+}

--- a/lib/vscode/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/lib/vscode/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -40,6 +40,7 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { IsWebContext } from 'vs/platform/contextkey/common/contextkeys';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ILogService } from 'vs/platform/log/common/log';
+import { Cookie } from 'vs/server/common/cookie';
 
 export abstract class MenubarControl extends Disposable {
 

--- a/lib/vscode/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/lib/vscode/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -9,8 +9,7 @@ import { registerThemingParticipant, IThemeService } from 'vs/platform/theme/com
 import { MenuBarVisibility, getTitleBarStyle, IWindowOpenable, getMenuBarVisibility } from 'vs/platform/windows/common/windows';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IAction, Action, SubmenuAction, Separator } from 'vs/base/common/actions';
-import * as DOM from 'vs/base/browser/dom';
-import { addDisposableListener, Dimension, EventType } from 'vs/base/browser/dom';
+import { addDisposableListener, Dimension, EventType, getCookieValue } from 'vs/base/browser/dom';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { isMacintosh, isWeb, isIOS, isNative } from 'vs/base/common/platform';
 import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
@@ -717,8 +716,8 @@ export class CustomMenubarControl extends MenubarControl {
 
 		webNavigationActions.push(new Action('logout', localize('logout', "Log out"), undefined, true,
 		async (event?: MouseEvent) => {
-			const COOKIE_KEY = 'key';
-			const loginCookie = DOM.getCookieValue(COOKIE_KEY);
+			const COOKIE_KEY = Cookie.Key;
+			const loginCookie = getCookieValue(COOKIE_KEY);
 
 			this.logService.info('Logging out of code-server');
 
@@ -735,7 +734,7 @@ export class CustomMenubarControl extends MenubarControl {
 			} else {
 				this.logService.warn('Could not log out because we could not find cookie');
 			}
-		}))
+		}));
 
 		return webNavigationActions;
 	}

--- a/lib/vscode/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/lib/vscode/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -9,6 +9,7 @@ import { registerThemingParticipant, IThemeService } from 'vs/platform/theme/com
 import { MenuBarVisibility, getTitleBarStyle, IWindowOpenable, getMenuBarVisibility } from 'vs/platform/windows/common/windows';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IAction, Action, SubmenuAction, Separator } from 'vs/base/common/actions';
+import * as DOM from 'vs/base/browser/dom';
 import { addDisposableListener, Dimension, EventType } from 'vs/base/browser/dom';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { isMacintosh, isWeb, isIOS, isNative } from 'vs/base/common/platform';
@@ -38,6 +39,7 @@ import { KeyCode } from 'vs/base/common/keyCodes';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IsWebContext } from 'vs/platform/contextkey/common/contextkeys';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export abstract class MenubarControl extends Disposable {
 
@@ -312,7 +314,8 @@ export class CustomMenubarControl extends MenubarControl {
 		@IThemeService private readonly themeService: IThemeService,
 		@IWorkbenchLayoutService private readonly layoutService: IWorkbenchLayoutService,
 		@IHostService protected readonly hostService: IHostService,
-		@ICommandService commandService: ICommandService
+		@ICommandService commandService: ICommandService,
+		@ILogService private readonly logService: ILogService
 	) {
 		super(menuService, workspacesService, contextKeyService, keybindingService, configurationService, labelService, updateService, storageService, notificationService, preferencesService, environmentService, accessibilityService, hostService, commandService);
 
@@ -710,6 +713,28 @@ export class CustomMenubarControl extends MenubarControl {
 		if (webNavigationActions.length) {
 			webNavigationActions.pop();
 		}
+
+		webNavigationActions.push(new Action('logout', localize('logout', "Log out"), undefined, true,
+		async (event?: MouseEvent) => {
+			const COOKIE_KEY = 'key';
+			const loginCookie = DOM.getCookieValue(COOKIE_KEY);
+
+			this.logService.info('Logging out of code-server');
+
+			if(loginCookie) {
+				this.logService.info(`Removing cookie under ${COOKIE_KEY}`);
+
+				if (document && document.cookie) {
+					// We delete the cookie by setting the expiration to a date/time in the past
+					document.cookie = COOKIE_KEY +'=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+					window.location.href = '/login';
+				} else {
+					this.logService.warn('Could not delete cookie because document and/or document.cookie is undefined');
+				}
+			} else {
+				this.logService.warn('Could not log out because we could not find cookie');
+			}
+		}))
 
 		return webNavigationActions;
 	}

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -3,13 +3,10 @@ import { promises as fs } from "fs"
 import { RateLimiter as Limiter } from "limiter"
 import * as path from "path"
 import safeCompare from "safe-compare"
+import { Cookie } from "../../../lib/vscode/src/vs/server/common/cookie"
 import { rootPath } from "../constants"
 import { authenticated, getCookieDomain, redirect, replaceTemplates } from "../http"
 import { hash, humanPath } from "../util"
-
-export enum Cookie {
-  Key = "key",
-}
 
 // RateLimiter wraps around the limiter library for logins.
 // It allows 2 logins every minute and 12 logins every hour.

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -3,10 +3,13 @@ import { promises as fs } from "fs"
 import { RateLimiter as Limiter } from "limiter"
 import * as path from "path"
 import safeCompare from "safe-compare"
-import { Cookie } from "../../../lib/vscode/src/vs/server/common/cookie"
 import { rootPath } from "../constants"
 import { authenticated, getCookieDomain, redirect, replaceTemplates } from "../http"
 import { hash, humanPath } from "../util"
+
+export enum Cookie {
+  Key = "key",
+}
 
 // RateLimiter wraps around the limiter library for logins.
 // It allows 2 logins every minute and 12 logins every hour.

--- a/test/e2e/logout.test.ts
+++ b/test/e2e/logout.test.ts
@@ -47,11 +47,8 @@ describe("logout", () => {
     await page.hover(logoutButton)
 
     await page.click(logoutButton)
-    // it takes a second to navigate
-    // and since page.url comes back immediately
-    // we need this waitForNavigation, otherwise it will check
-    // before navigation has finished and fail
-    await page.waitForNavigation({ url: `${CODE_SERVER_ADDRESS}/login` })
+    // it takes a couple seconds to navigate
+    await page.waitForTimeout(2000)
     const currentUrl = page.url()
     expect(currentUrl).toBe(`${CODE_SERVER_ADDRESS}/login`)
   })

--- a/test/e2e/logout.test.ts
+++ b/test/e2e/logout.test.ts
@@ -1,0 +1,58 @@
+import { chromium, Page, Browser, BrowserContext } from "playwright"
+import { CODE_SERVER_ADDRESS, PASSWORD, E2E_VIDEO_DIR } from "../utils/constants"
+
+describe("logout", () => {
+  let browser: Browser
+  let page: Page
+  let context: BrowserContext
+
+  beforeAll(async () => {
+    browser = await chromium.launch()
+    context = await browser.newContext({
+      recordVideo: { dir: E2E_VIDEO_DIR },
+    })
+  })
+
+  afterAll(async () => {
+    await browser.close()
+  })
+
+  beforeEach(async () => {
+    page = await context.newPage()
+  })
+
+  afterEach(async () => {
+    await page.close()
+    // Remove password from local storage
+    await context.clearCookies()
+  })
+
+  it("should be able login and logout", async () => {
+    await page.goto(CODE_SERVER_ADDRESS)
+    // Type in password
+    await page.fill(".password", PASSWORD)
+    // Click the submit button and login
+    await page.click(".submit")
+    // See the editor
+    const codeServerEditor = await page.isVisible(".monaco-workbench")
+    expect(codeServerEditor).toBeTruthy()
+
+    // Click the Application menu
+    await page.click("[aria-label='Application Menu']")
+
+    // See the Log out button
+    const logoutButton = "a.action-menu-item span[aria-label='Log out']"
+    expect(await page.isVisible(logoutButton))
+
+    await page.hover(logoutButton)
+
+    await page.click(logoutButton)
+    // it takes a second to navigate
+    // and since page.url comes back immediately
+    // we need this waitForNavigation, otherwise it will check
+    // before navigation has finished and fail
+    await page.waitForNavigation({ url: `${CODE_SERVER_ADDRESS}/login` })
+    const currentUrl = page.url()
+    expect(currentUrl).toBe(`${CODE_SERVER_ADDRESS}/login`)
+  })
+})


### PR DESCRIPTION
This adds a new option to the Application Menu called Log out. It deletes the code-server cookie and logs a user out.

## Screenshot
![2021-03-17 15 31 46](https://user-images.githubusercontent.com/3806031/111547536-8c7e4000-8736-11eb-8b1a-a6294b51757d.gif)

## TODOs
- [x] use vscode logger
- [x] refactor `Cookie` to be in `lib/vscode` so we can use it
- [x] write e2e test
- [x] refactor `Cookie` and don't share between `lib/vscode`


Fixes #778 