### PR TITLE
chore(ci): test if github injects some form of yarn cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,15 @@ jobs:
         with:
           args: ./ci/steps/lint.sh
 
+  sanity-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Quick sanity checks
+        uses: ./ci/images/debian10
+        with:
+          args: ./ci/steps/cache.sh
+
   test-unit:
     runs-on: ubuntu-latest
     steps:

--- a/ci/steps/cache.sh
+++ b/ci/steps/cache.sh
@@ -3,4 +3,7 @@
 # check for yarn cache
 ls -l ~/.cache/yarn
 # check size
-echo "$(ls -l ~/.cache/yarn/v6 | wc -l) packages in cache"
+echo "$(find ~/.cache/yarn/v6 -maxdepth 1 | wc -l) packages in cache"
+
+# check for other items in cache
+ls -l ~/.cache

--- a/ci/steps/cache.sh
+++ b/ci/steps/cache.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# check for yarn cache
+ls -l ~/.cache/yarn
+# check size
+echo "$(ls -l ~/.cache/yarn/v6 | wc -l) packages in cache"


### PR DESCRIPTION
Sanity check to see if we secretly get some form of yarn cache as a favor from GitHub?
There's a reason for this test which I can't share publicly _yet_, I'll update this to be more transparent when I can.