### PR TITLE
refactor: change get_artifacts_url in lib.sh

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -57,13 +57,16 @@ curl() {
 # This will contain the artifacts we want.
 # https://developer.github.com/v3/actions/workflow-runs/#list-workflow-runs
 get_artifacts_url() {
-  local head_sha
   local artifacts_url
-  head_sha=$(git rev-parse HEAD)
-  artifacts_url=$(curl -fsSL 'https://api.github.com/repos/cdr/code-server/actions/workflows/ci.yaml/runs?status=success&event=pull_request' | jq -r ".workflow_runs[] | select(.head_sha == \"$head_sha\") | .artifacts_url" | head -n 1)
+  local workflow_runs_url="https://api.github.com/repos/cdr/code-server/actions/workflows/ci.yaml/runs?status=success&event=pull_request"
+  # For releases, we look for run based on the branch name v$code_server_version
+  # example: v3.9.2
+  local version_branch="v$VERSION"
+  artifacts_url=$(curl -fsSL "$workflow_runs_url" | jq -r ".workflow_runs[] | select(.head_branch == \"$version_branch\") | .artifacts_url" | head -n 1)
   if [[ -z "$artifacts_url" ]]; then
     echo >&2 "ERROR: artifacts_url came back empty"
-    echo >&2 "Check the get_artifacts_url function"
+    echo >&2 "We looked for a successful run triggered by a pull_request with for code-server version: $code_server_version and a branch named $version_branch"
+    echo >&2 "URL used for curl call: $workflow_runs_url"
     exit 1
   fi
 


### PR DESCRIPTION
This PR refactors get_artifacts_url in lib.sh to work of the version branch instead of the head sha.