### PR TITLE
Don't send permessage-deflate header if not supported

### DIFF
--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -210,7 +210,9 @@ wsRouter.ws("/", ensureAuthenticated, async (req) => {
   // TODO: Parse this header properly.
   const extensions = req.headers["sec-websocket-extensions"]
   const permessageDeflate = extensions ? extensions.includes("permessage-deflate") : false
-  responseHeaders.push("Sec-WebSocket-Extensions: permessage-deflate; server_max_window_bits=15")
+  if (permessageDeflate) {
+    responseHeaders.push("Sec-WebSocket-Extensions: permessage-deflate; server_max_window_bits=15")
+  }
 
   req.ws.write(responseHeaders.join("\r\n") + "\r\n\r\n")
 


### PR DESCRIPTION
I have no idea if this fixes https://github.com/cdr/code-server/issues/2975 since I don't have a way to test.

TODOS 
- [ ] create follow-up issue to enable e2d testing on Safari to catch this in the future (@jsjoeio)