### PR TITLE
fix(dev-deps): update ts-node and spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "prettier-plugin-sh": "^0.6.0",
     "stylelint": "^13.0.0",
     "stylelint-config-recommended": "^4.0.0",
-    "ts-node": "~9.0.0",
+    "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
     "wtfnode": "^0.8.4"
   },

--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -314,7 +314,7 @@ export class ParentProcess extends Process {
         CODE_SERVER_PARENT_PID: process.pid.toString(),
         NODE_OPTIONS: `--max-old-space-size=2048 ${process.env.NODE_OPTIONS || ""}`,
       },
-      stdio: ["ipc"],
+      stdio: ["inherit", "pipe", "pipe", "ipc"],
     })
   }
 

--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -314,7 +314,7 @@ export class ParentProcess extends Process {
         CODE_SERVER_PARENT_PID: process.pid.toString(),
         NODE_OPTIONS: `--max-old-space-size=2048 ${process.env.NODE_OPTIONS || ""}`,
       },
-      stdio: ["inherit", "pipe", "pipe", "ipc"],
+      stdio: ["inherit", "inherit", "inherit", "ipc"],
     })
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,6 +2415,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^6.0.4:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -7517,12 +7522,13 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.5.tgz#b8b639cefad7d0bb2abd37d433ff8293efa5f406"
   integrity sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==
 
-ts-node@~9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.0.0.tgz#e7699d2a110cc8c0d3b831715e417688683460b3"
-  integrity sha512-/TqB4SnererCDR/vb4S/QvSZvzQMJN8daAslg7MeaiHvD8rDZsSfXmNeNumyZZzMned72Xoq/isQljYSt8Ynfg==
+ts-node@^9.1.1:
+  version "9.1.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-9.1.1.tgz#51a9a450a3e959401bda5f004a72d54b936d376d"
+  integrity sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==
   dependencies:
     arg "^4.1.0"
+    create-require "^1.1.0"
     diff "^4.0.1"
     make-error "^1.1.1"
     source-map-support "^0.5.17"


### PR DESCRIPTION
This PR fixes how we spawn a child_process and bumps `ts-node`.

(H/T to @cspotcode for identifying this after we opened an issue in `ts-node`)

Related:
- https://github.com/TypeStrong/ts-node/issues/1283#issuecomment-807704228
- Reverts https://github.com/cdr/code-server/pull/2962
- https://github.com/cdr/code-server/pull/2965


<img width="1792" alt="image" src="https://user-images.githubusercontent.com/3806031/112900381-4317e400-9098-11eb-9972-1b2878fed5cc.png">
