### PR TITLE
chore(dev-deps): add ignore block to dependabot config for @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,6 @@ updates:
     schedule:
       interval: "daily"
       time: "11:00"
+    ignore:
+      - dependency-name: "@types/node"
+        versions: ["14.x"]


### PR DESCRIPTION
This PR tells dependabot to ignore version updates for @types/node 14.x. 

Related:
- https://github.com/cdr/code-server/pull/2989#issuecomment-809551319