### PR TITLE
chore(dev-deps): ignore 13.x updates for @types/node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,4 +17,4 @@ updates:
       time: "11:00"
     ignore:
       - dependency-name: "@types/node"
-        versions: ["14.x"]
+        versions: ["14.x", "13.x"]


### PR DESCRIPTION
This should tell Dependabot to ignore 13.x updates for @types/node.

Related:
- #3006 