### PR TITLE
feat(ci): add homebrew job to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,3 +33,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+  homebrew:
+    # The newest version of code-server needs to be available on npm when this runs
+    # otherwise, it will 404 and won't open a PR to bump version on homebrew/homebrew-core
+    needs: npm
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Configure git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+      - name: Bump code-server homebrew version
+        env:
+          HOMEBREW_GITHUB_API_TOKEN: ${{secrets.HOMEBREW_GITHUB_API_TOKEN}}
+        run: ./ci/steps/brew-bump.sh

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+  cd "$(dirname "$0")/../.."
+  # Only sourcing this so we get access to $VERSION
+  source ./ci/lib.sh
+  # Find the docs for bump-formula-pr here
+  # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18
+  brew bump-formula-pr --force --version="${VERSION}" code-server --no-browse --no-audit
+}
+
+main "$@"


### PR DESCRIPTION
This PR adds a new job to the `publish` workflow to automatically bump the code-server version on homebrew.

## Notes
It failed because `3.9.3` isn't out yet, but I think it *should* work.

<img width="643" alt="image" src="https://user-images.githubusercontent.com/3806031/113220041-6036e900-9237-11eb-83b6-53c56b904274.png">

## TODOs
- [x] update secret in code-server settings once you get access to cdrci account from @kylecarbs 
