### PR TITLE
chore(dev-deps): bump @types/node to 12.20.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/express": "^4.17.8",
     "@types/http-proxy": "^1.17.4",
     "@types/js-yaml": "^4.0.0",
-    "@types/node": "^12.12.7",
+    "@types/node": "~12.20.7",
     "@types/parcel-bundler": "^1.12.1",
     "@types/pem": "^1.9.5",
     "@types/proxy-from-env": "^1.0.1",
@@ -72,7 +72,6 @@
     "wtfnode": "^0.8.4"
   },
   "resolutions": {
-    "@types/node": "^12.12.7",
     "safe-buffer": "^5.1.1",
     "vfile-message": "^2.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,7 +1167,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.1.tgz#283f669ff76d7b8260df8ab7a4262cc83d988256"
   integrity sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
 
-"@types/node@*", "@types/node@^12.12.7":
+"@types/node@*", "@types/node@~12.20.7":
   version "12.20.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8"
   integrity sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==


### PR DESCRIPTION
This PR bumps `@types/node` to `12.20.7`

Tested locally using `node 12.20.2` and everything works as expected.

Related:
- https://github.com/cdr/code-server/pull/3011