### PR TITLE
fix: update ranger file

### DIFF
--- a/.github/ranger.yml
+++ b/.github/ranger.yml
@@ -4,12 +4,10 @@ default:
   close:
     # Default time to wait before closing the label. Can either be a number in milliseconds
     # or a string specified by the `ms` package (https://www.npmjs.com/package/ms)
-    delay: "3 days"
+    delay: "2 days"
 
     # Default comment to post when an issue is first marked with a closing label
     comment: "⚠️ This issue has been marked $LABEL and will be closed in $DELAY."
-  close-faster:
-    delay: "1 minute"
 
 labels:
   duplicate: close
@@ -26,7 +24,7 @@ labels:
     delay: 5s
     message: "Thanks for making your first contribution! :slightly_smiling_face:"
   extension-request:
-    action: close-faster
+    action: close
     delay: 5s
     message: >
       Thanks for opening an extension request!
@@ -38,7 +36,7 @@ labels:
       file and then installing into code-server as a temporary workaround.
       See [docs](https://github.com/cdr/code-server/blob/main/docs/FAQ.md#installing-vsix-extensions-via-the-command-line) for more info."
   "upstream:vscode":
-    action: close-faster
+    action: close
     delay: 5s
     comment: >
       This issue has been marked as 'upstream:vscode'.


### PR DESCRIPTION
This PR fixes a couple syntax issues in the `ranger.yml` configuration and adjusts the close time to 2 days instead of 3.

I thought we could define our own custom actions but I don't think that's the case after re-reading [the docs](https://www.notion.so/Documentation-8d7627bb1f3c42b7b1820e8d6f157a57) and asking the maintainer why it wasn't working 😂.