### PR TITLE
release: 3.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # code-server &middot; [!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
 
-![Lines](https://img.shields.io/badge/Coverage-51.55%25-red.svg)
-[![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.9.2/docs)
+![Lines](https://img.shields.io/badge/Coverage-51.47%25-green.svg)
+[![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.9.3/docs)
 
 Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and access it in the browser.
 

--- a/ci/build/release-prep.sh
+++ b/ci/build/release-prep.sh
@@ -86,7 +86,7 @@ main() {
   # Updates the Lines badge in the README
   $CMD yarn badges
   # Updates the svg to be green for the badge
-  $CMD sd "red.svg" "green.svg" ../../README.md
+  $CMD sd "red.svg" "green.svg" ./README.md
 
   $CMD git commit -am "chore(release): bump version to $CODE_SERVER_VERSION_TO_UPDATE"
 

--- a/ci/build/release-prep.sh
+++ b/ci/build/release-prep.sh
@@ -68,6 +68,17 @@ main() {
     exit
   fi
 
+  # Note: we need to set upstream as well or the gh pr create step will fail
+  # See: https://github.com/cli/cli/issues/575
+  CURRENT_BRANCH=$(git branch | grep '\*' | cut -d' ' -f2-)
+  if [[ -z $(git config "branch.${CURRENT_BRANCH}.remote") ]]; then
+    echo "Doesn't look like you've pushed this branch to remote"
+    # Note: we need to set upstream as well or the gh pr create step will fail
+    # See: https://github.com/cli/cli/issues/575
+    echo "Please set the upstream and then run the script"
+    exit 1
+  fi
+
   # credit to jakwuh for this solution
   # https://gist.github.com/DarrenN/8c6a5b969481725a4413#gistcomment-1971123
   CODE_SERVER_CURRENT_VERSION=$(node -pe "require('./package.json').version")
@@ -89,18 +100,6 @@ main() {
   $CMD sd "red.svg" "green.svg" ./README.md
 
   $CMD git commit -am "chore(release): bump version to $CODE_SERVER_VERSION_TO_UPDATE"
-
-  # Note: we need to set upstream as well or the gh pr create step will fail
-  # See: https://github.com/cli/cli/issues/575
-  CURRENT_BRANCH=$(git branch | grep '\*' | cut -d' ' -f2-)
-  if [[ -z $(git config "branch.${CURRENT_BRANCH}.remote") ]]; then
-    echo "Doesn't look like you've pushed this branch to remote"
-    echo -e "Pushing now using: git push origin $CURRENT_BRANCH\n"
-    # Note: we need to set upstream as well or the gh pr create step will fail
-    # See: https://github.com/cli/cli/issues/575
-    echo "Please set the upstream and re-run the script"
-    exit 1
-  fi
 
   # This runs from the root so that's why we use this path vs. ../../
   RELEASE_TEMPLATE_STRING=$(cat ./.github/PULL_REQUEST_TEMPLATE/release_template.md)

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.9.2
+appVersion: 3.9.3

--- a/ci/helm-chart/README.md
+++ b/ci/helm-chart/README.md
@@ -1,6 +1,6 @@
 # code-server
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.2](https://img.shields.io/badge/AppVersion-3.9.2-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
 
 [code-server](https://github.com/cdr/code-server) code-server is VS Code running
 on a remote server, accessible through the browser.
@@ -72,7 +72,7 @@ and their default values.
 | hostnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"codercom/code-server"` |  |
-| image.tag | string | `"3.9.2"` |  |
+| image.tag | string | `"3.9.3"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '3.9.2'
+  tag: '3.9.3'
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -60,7 +60,7 @@ get_artifacts_url() {
   local artifacts_url
   local workflow_runs_url="https://api.github.com/repos/cdr/code-server/actions/workflows/ci.yaml/runs?status=success&event=pull_request"
   # For releases, we look for run based on the branch name v$code_server_version
-  # example: v3.9.2
+  # example: v3.9.3
   local version_branch="v$VERSION"
   artifacts_url=$(curl -fsSL "$workflow_runs_url" | jq -r ".workflow_runs[] | select(.head_branch == \"$version_branch\") | .artifacts_url" | head -n 1)
   if [[ -z "$artifacts_url" ]]; then

--- a/docs/install.md
+++ b/docs/install.md
@@ -93,8 +93,8 @@ NOTE: The standalone arm64 .deb does not support Ubuntu <16.04.
 Please upgrade or [build with yarn](#yarn-npm).
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.9.2/code-server_3.9.2_amd64.deb
-sudo dpkg -i code-server_3.9.2_amd64.deb
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.9.3/code-server_3.9.3_amd64.deb
+sudo dpkg -i code-server_3.9.3_amd64.deb
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -105,8 +105,8 @@ NOTE: The standalone arm64 .rpm does not support CentOS 7.
 Please upgrade or [build with yarn](#yarn-npm).
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.9.2/code-server-3.9.2-amd64.rpm
-sudo rpm -i code-server-3.9.2-amd64.rpm
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.9.3/code-server-3.9.3-amd64.rpm
+sudo rpm -i code-server-3.9.3-amd64.rpm
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -205,10 +205,10 @@ Here is an example script for installing and using a standalone `code-server` re
 
 ```bash
 mkdir -p ~/.local/lib ~/.local/bin
-curl -fL https://github.com/cdr/code-server/releases/download/v3.9.2/code-server-3.9.2-linux-amd64.tar.gz \
+curl -fL https://github.com/cdr/code-server/releases/download/v3.9.3/code-server-3.9.3-linux-amd64.tar.gz \
   | tar -C ~/.local/lib -xz
-mv ~/.local/lib/code-server-3.9.2-linux-amd64 ~/.local/lib/code-server-3.9.2
-ln -s ~/.local/lib/code-server-3.9.2/bin/code-server ~/.local/bin/code-server
+mv ~/.local/lib/code-server-3.9.3-linux-amd64 ~/.local/lib/code-server-3.9.3
+ln -s ~/.local/lib/code-server-3.9.3/bin/code-server ~/.local/bin/code-server
 PATH="~/.local/bin:$PATH"
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml

--- a/install.sh
+++ b/install.sh
@@ -419,7 +419,7 @@ install_npm() {
   echoh
   echoerr "Please install npm or yarn to install code-server!"
   echoerr "You will need at least node v12 and a few C dependencies."
-  echoerr "See the docs https://github.com/cdr/code-server/blob/v3.9.2/docs/install.md#yarn-npm"
+  echoerr "See the docs https://github.com/cdr/code-server/blob/v3.9.3/docs/install.md#yarn-npm"
   exit 1
 }
 

--- a/lib/vscode/test/smoke/package.json
+++ b/lib/vscode/test/smoke/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^12.19.9",
     "@types/rimraf": "^2.0.4",
     "cpx": "^1.5.0",
-    "htmlparser2": "^3.9.2",
+    "htmlparser2": "^3.9.3",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0",
     "npm-run-all": "^4.1.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/cdr/code-server",
   "bugs": {


### PR DESCRIPTION
<!-- Note: this variable $CODE_SERVER_VERSION_TO_UPDATE will be set when you run the release-prep.sh script with `yarn release:prep` -->

This PR is to generate a new release of `code-server` at `3.9.3`

## Screenshot

https://user-images.githubusercontent.com/3806031/114092048-4bc5a280-986e-11eb-9798-7f430a873e4f.mov



## TODOs

- [x] upload assets to draft release
- [x] double-check github release tag is the commit with artifacts (_note gets messed up after uploading assets_)
- [x] test locally
- [x] test one of the release packages locally
- [ ] publish release
- [ ] merge PR
- [ ] update the homebrew package
- [ ] update the AUR package