### PR TITLE
docs: add security policy

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version of `code-server` is currently support with security updates. These security updates will be patched in the version after the current version.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.9.3   | :white_check_mark: |
+
+## Reporting a Vulnerability
+
+To report a vulnerability, please send an email to security[@]coder.com and our security team will respond to you.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Only the latest version of `code-server` is currently support with security updates. These security updates will be patched in the version after the current version.
+Coder sponsors development and maintenance of the code-server project. We will fix security issues within 90 days of receiving a report, and publish the fix in a subsequent release. The code-server project does not provide backports or patch releases for security issues at this time.
 
 | Version | Supported          |
 | ------- | ------------------ |


### PR DESCRIPTION
This PR adds a security policy for how we handle vulnerabilities in code-server.

See ["Adding a security policy to your repository"](https://docs.github.com/en/code-security/security-advisories/adding-a-security-policy-to-your-repository) for more information.