### PR TITLE
chore(ci): migrate from hub to gh

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -24,8 +24,7 @@ Any file or directory in this subdirectory should be documented here.
    - It will upload them to the draft release.
 6. Run some basic sanity tests on one of the released packages.
    - Especially make sure the terminal works fine.
-7. Make sure the github release tag is the commit with the artifacts. This is a bug in
-   `hub` where uploading assets in step 5 will break the tag.
+7. Make sure the github release tag is the commit with the artifacts.
 8. Publish the release and merge the PR.
    1. CI will automatically grab the artifacts and then:
       1. Publish the NPM package from `npm-package`.
@@ -106,10 +105,10 @@ You can disable minification by setting `MINIFY=`.
 - [./ci/build/code-server.service](./build/code-server.service)
   - systemd user service packaged into the `.deb` and `.rpm`.
 - [./ci/build/release-github-draft.sh](./build/release-github-draft.sh) (`yarn release:github-draft`)
-  - Uses [hub](https://github.com/github/hub) to create a draft release with a template description.
+  - Uses [gh](https://github.com/cli/cli) to create a draft release with a template description.
 - [./ci/build/release-github-assets.sh](./build/release-github-assets.sh) (`yarn release:github-assets`)
   - Downloads the release-package artifacts for the current commit from CI.
-  - Uses [hub](https://github.com/github/hub) to upload the artifacts to the release
+  - Uses [gh](https://github.com/cli/cli) to upload the artifacts to the release
     specified in `package.json`.
 - [./ci/build/npm-postinstall.sh](./build/npm-postinstall.sh)
   - Post install script for the npm package.

--- a/ci/build/release-github-assets.sh
+++ b/ci/build/release-github-assets.sh
@@ -15,7 +15,7 @@ main() {
   for i in "${!assets[@]}"; do
     assets[$i]="--attach=${assets[$i]}"
   done
-  EDITOR=true hub release edit --draft "${assets[@]}" "v$VERSION"
+  EDITOR=true gh release upload "v$VERSION" "${assets[@]}"
 }
 
 main "$@"

--- a/ci/build/release-github-draft.sh
+++ b/ci/build/release-github-draft.sh
@@ -7,10 +7,10 @@ main() {
   cd "$(dirname "$0")/../.."
   source ./ci/lib.sh
 
-  hub release create \
-    --file - \
-    -t "$(git rev-parse HEAD)" \
-    --draft "v$VERSION" <<EOF
+  gh release create "v$VERSION" \
+    --notes-file - \
+    --target "$(git rev-parse HEAD)" \
+    --draft <<EOF
 v$VERSION
 
 VS Code v$(vscode_version)

--- a/ci/build/release-prep.sh
+++ b/ci/build/release-prep.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Description: This is a script to make the release process easier
 # Run it with `yarn release:prep` and it will do the following:
-# 1. Check that you have a $GITHUB_TOKEN set and hub installed
+# 1. Check that you have gh installed and that you're signed in
 # 2. Update the version of code-server (package.json, docs, etc.)
 # 3. Update the code coverage badge in the README
 # 4. Open a draft PR using the release_template.md and view in browser
@@ -19,19 +19,11 @@ main() {
 
   cd "$(dirname "$0")/../.."
 
-  # Check that $GITHUB_TOKEN is set
-  if [[ -z ${GITHUB_TOKEN-} ]]; then
-    echo "We couldn't find an environment variable under GITHUB_TOKEN."
-    echo "This is needed for our scripts that use hub."
-    echo -e "See docs regarding GITHUB_TOKEN here under 'GitHub OAuth authentication': https://hub.github.com/hub.1.html"
-    exit
-  fi
-
-  # Check that hub is installed
-  if ! command -v hub &>/dev/null; then
-    echo "hub could not be found."
+  # Check that gh is installed
+  if ! command -v gh &>/dev/null; then
+    echo "gh could not be found."
     echo "We use this with the release-github-draft.sh and release-github-assets.sh scripts."
-    echo -e "See docs here: https://github.com/github/hub#installation"
+    echo -e "See docs here: https://github.com/cli/cli#installation"
     exit
   fi
 
@@ -65,6 +57,14 @@ main() {
     echo "That's surprising..."
     echo "We use it in this script for getting the package.json version"
     echo -e "See docs here: https://nodejs.org/en/download/"
+    exit
+  fi
+
+  # Check that gh is authenticated
+  if ! gh auth status -h github.com &>/dev/null; then
+    echo "gh isn't authenticated to github.com."
+    echo "This is needed for our scripts that use gh."
+    echo -e "See docs regarding authentication: https://cli.github.com/manual/gh_auth_login"
     exit
   fi
 


### PR DESCRIPTION
Notes -
In addition to moving our two `hub` calls to `gh`, I also replaced the `curl` calls that depend on `GITHUB_TOKEN` being set in `ci/lib.sh` with `gh api` calls instead; the benefit is that this also allows alternative auth (stored in `~/.config/gh/hosts.yml` instead of env).

Closes #2960.