### PR TITLE
chore(ranger): fix syntax for extension-request

### DIFF
--- a/.github/ranger.yml
+++ b/.github/ranger.yml
@@ -26,7 +26,7 @@ labels:
   extension-request:
     action: close
     delay: 5s
-    message: >
+    comment: >
       Thanks for opening an extension request!
       We are currently in the process of switching extension
       marketplaces and transitioning over to [Open VSX](https://open-vsx.org/).


### PR DESCRIPTION
I wish GitHub integrations would give us red squiggles in the file when we mess up the syntax. Oh, well!