### PR TITLE
feat(testing): add tests for registerServiceWorker

### DIFF
--- a/src/browser/register.ts
+++ b/src/browser/register.ts
@@ -4,12 +4,12 @@ import "./pages/error.css"
 import "./pages/global.css"
 import "./pages/login.css"
 
-async function registerServiceWorker(): Promise<void> {
+export async function registerServiceWorker(): Promise<void> {
   const options = getOptions()
   const path = normalize(`${options.csStaticBase}/dist/serviceWorker.js`)
   try {
     await navigator.serviceWorker.register(path, {
-      scope: (options.base ?? "") + "/",
+      scope: options.base + "/",
     })
     console.log("[Service Worker] registered")
   } catch (error) {

--- a/test/unit/register.test.ts
+++ b/test/unit/register.test.ts
@@ -105,7 +105,6 @@ describe("register", () => {
       const location: LocationLike = {
         pathname: "",
         origin: "http://localhost:8080",
-        // search: "?environmentId=600e0187-0909d8a00cb0a394720d4dce",
       }
       const { window } = new JSDOM()
       global.window = (window as unknown) as Window & typeof globalThis

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -16,7 +16,7 @@ import { loggerModule } from "../utils/helpers"
 const dom = new JSDOM()
 global.document = dom.window.document
 
-type LocationLike = Pick<Location, "pathname" | "origin">
+export type LocationLike = Pick<Location, "pathname" | "origin">
 
 // jest.mock is hoisted above the imports so we must use `require` here.
 jest.mock("@coder/logger", () => require("../utils/helpers").loggerModule)


### PR DESCRIPTION
This PR adds two more tests to cover the last line for `src/browser/register.ts` which should be at 100% now. 

![image](https://user-images.githubusercontent.com/3806031/115939823-419dc980-a454-11eb-8543-ac0658e74af6.png)


Interestingly - the output from Jest and what Codecov picks up are a little different 🤷‍♂️



