### PR TITLE
Revamp debugging section

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,9 +10,14 @@ assignees: ""
 
 Hi there! 👋
 
-Thanks for reporting a bug. Please see https://github.com/cdr/code-server/blob/main/docs/FAQ.md#how-do-i-debug-issues-with-code-server and include any logging information relevant to the issue.
+Thanks for reporting a bug.
 
-Please search for existing issues before filing, as they may contain additional information about the problem and descriptions of workarounds. Provide as much information as you can, so that we can reproduce the issue. Otherwise, we may not be able to help diagnose the problem, and may close the issue as unreproducible or incomplete. For visual defects, please include screenshots to help us understand the issue.
+Please search for existing issues before filing, as they may contain additional
+information about the problem and descriptions of workarounds. Provide as much
+information as you can, so that we can reproduce the issue. Otherwise, we may
+not be able to help diagnose the problem, and may close the issue as
+unreproducible or incomplete. For visual defects, please include screenshots to
+help us understand the issue.
 -->
 
 ## OS/Web Information
@@ -37,9 +42,29 @@ Please search for existing issues before filing, as they may contain additional 
 
 <!-- What actually happens? -->
 
+## Logs
+
+<!--
+First run code-server with at least debug logging (or trace to be really
+thorough) by setting the --log flag or the LOG_LEVEL environment variable. -vvv
+and --verbose are aliases for --log trace. For example:
+
+code-server --log debug
+
+Once this is done, replicate the issue you're having then collect logging
+information from the following places:
+
+    1. The most recent files from ~/.local/share/code-server/coder-logs.
+    2. The browser console.
+    3. The browser network tab.
+
+Additionally, collecting core dumps (you may need to enable them first) if
+code-server crashes can be helpful.
+-->
+
 ## Screenshot
 
-<!-- Ideally provide a screenshot, gif, video or screenrecording -->
+<!-- Ideally provide a screenshot, gif, video or screen recording. -->
 
 ## Notes
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -330,8 +330,8 @@ Once this is done, replicate the issue you're having then collect logging
 information from the following places:
 
 1. The most recent files from `~/.local/share/code-server/coder-logs`.
-2. The most recently created directory in the `~/.local/share/code-server/logs` directory.
-3. The browser console and network tabs.
+2. The browser console.
+3. The browser network tab.
 
 Additionally, collecting core dumps (you may need to enable them first) if
 code-server crashes can be helpful.


### PR DESCRIPTION
- Most people leave the logs out so add a section for them in the issue
  template.
- Remove the VS Code logs because those get sent to stdout now and will
  show up in our logs.
- Separate browser console and network.