### PR TITLE
docs(maintaining): use milestones over boards

### DIFF
--- a/ci/dev/fmt.sh
+++ b/ci/dev/fmt.sh
@@ -27,6 +27,7 @@ main() {
   doctoc --title '# Install' docs/install.md >/dev/null
   doctoc --title '# npm Install Requirements' docs/npm.md >/dev/null
   doctoc --title '# Contributing' docs/CONTRIBUTING.md >/dev/null
+  doctoc --title '# Maintaining' docs/MAINTAINING.md >/dev/null
   doctoc --title '# Contributor Covenant Code of Conduct' docs/CODE_OF_CONDUCT.md >/dev/null
   doctoc --title '# iPad' docs/ipad.md >/dev/null
 

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,0 +1,45 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+# Maintaining
+
+- [Maintaining](#maintaining)
+  - [Workflow](#workflow)
+    - [Milestones](#milestones)
+    - [Project Boards](#project-boards)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Maintaining
+
+Current maintainers:
+
+- @code-asher
+- @oxy
+- @jsjoeio
+
+This document is meant to serve current and future maintainers of code-server, but also share openly our workflow for maintaining the project.
+
+## Workflow
+
+The workflow used by code-server maintainers is one that aims to be easy to understood by the community and easy enough for new maintainers to jump in and start contributing on day one.
+
+### Milestones
+
+We operate mainly using [milestones](https://github.com/cdr/code-server/milestones). This was heavily inspired by our friends over at [vscode](https://github.com/microsoft/vscode).
+
+Here are the milestones we use and how we use them:
+
+- "Backlog" -> Work not yet planned for a specific release.
+- "On Deck" -> Work under consideration for upcoming milestones.
+- "Backlog Candidates" -> Work that is not yet accepted for the backlog. We wait for the community to weigh in.
+- "<0.0.0>" -> Work to be done for that version.
+
+With this flow, any un-assigned issues are essentially in triage state and once triaged are either "Backlog" or "Backlog Candidates". They will eventually move to "On Deck" (or be closed). Lastly, they will end up on a version milestone where they will be worked on.
+
+### Project Boards
+
+We use project boards for projects or goals that span multiple milestones.
+
+Think of this as a place to put miscellaneous things (like testing, clean up stuff, etc). As a maintainer, random todos may come up here and there. This gives you a place to add notes temporarily before opening a new issue. Given that our release milestones function off of issues, we believe tasks should have dedicated issues.
+
+It also gives us a way to separate the issue triage from bigger-picture, long-term work.

--- a/test/unit/register.test.ts
+++ b/test/unit/register.test.ts
@@ -1,6 +1,6 @@
 import { JSDOM } from "jsdom"
-import { loggerModule } from "../utils/helpers"
 import { registerServiceWorker } from "../../src/browser/register"
+import { loggerModule } from "../utils/helpers"
 import { LocationLike } from "./util.test"
 
 describe("register", () => {


### PR DESCRIPTION
## Current Workflow

Right now, the workflow looks a bit like this:
1. Issue comes in, assign to "triage" and ad relevant labels.
2. Once triaged is moved to next, it means we are working on it.
3. It may also get added to a version milestone if it will be out before that milestone is released.

We also have some work being added to the "On Deck" milestone. We would like to reduce any duplicate efforts and align ourselves with one process.

## Proposed Workflow

Use milestones instead of project boards (similar to how [vscode does it](https://github.com/microsoft/vscode/milestones)). 

Create the following milestones:
- "Backlog" -> Work not yet planned for a specific release.
- "On Deck" -> Work under consideration for upcoming milestones
- "Backlog Candidates" -> Work that is not yet accepted for the Backlog. We wait for the community to weigh in

Month milestones make more sense than version milestones because in the event that a milestone has work that affects the version then we'd need to change the milestone name.

### Pros

- Milestones live closer to the issues
- Milestones have progress indicators (open vs. closed in milestones)
- Milestones can have due dates
- Milestones can have descriptions

### Cons

- Issues can be attached to multiple milestones. This could lead to problems (potentially).

### Proposed Changes

Once we this PR is approved, these are the changes I (@jsjoeio) will own and take care of as part of this process:

- [ ] Create "Triage" milestone
- [ ] Create "Backlog" milestone
- [ ] Move all issues under "triage" in code-server project board to "Triage" milestone
- [ ] Move all issues under "Next" in code-server project board to "On Deck" milestone (if not already in version milestone)

## Follow-up 

- PR with proposal for changes to our triage workflow
- PR with proposal for documenting our versioning (aka how we bump versions)
- refactor/clean up our project boards (hopefully removing all except 🗺️ Roadmap)
