### PR TITLE
refactor(testing): fix flaky terminal test

### DIFF
--- a/test/e2e/models/CodeServer.ts
+++ b/test/e2e/models/CodeServer.ts
@@ -63,6 +63,7 @@ export class CodeServer {
     const isTerminalVisible = await this.page.isVisible("#terminal")
     if (isTerminalVisible) {
       await this.page.keyboard.press(`Control+Backquote`)
+      // TODO fix this
       // Wait for terminal to receive focus
       await this.page.waitForSelector("div.terminal.xterm.focus")
       // Sometimes the terminal reloads

--- a/test/e2e/models/CodeServer.ts
+++ b/test/e2e/models/CodeServer.ts
@@ -5,6 +5,7 @@ import { CODE_SERVER_ADDRESS } from "../../utils/constants"
 // See Playwright docs: https://playwright.dev/docs/pom/
 export class CodeServer {
   page: Page
+  editorSelector = "div.monaco-workbench"
 
   constructor(page: Page) {
     this.page = page
@@ -30,15 +31,18 @@ export class CodeServer {
     // but usually a reload or two fixes it
     // TODO@jsjoeio @oxy look into Firefox reconnection/timeout issues
     while (!editorIsVisible) {
+      // When a reload happens, we want to wait for all resources to be
+      // loaded completely. Hence why we use that instead of DOMContentLoaded
+      // Read more: https://thisthat.dev/dom-content-loaded-vs-load/
+      await this.page.waitForLoadState("load")
+      // Give it an extra second just in case it's feeling extra slow
+      await this.page.waitForTimeout(1000)
       reloadCount += 1
       if (await this.isEditorVisible()) {
         console.log(`    Editor became visible after ${reloadCount} reloads`)
         break
       }
-      // When a reload happens, we want to wait for all resources to be
-      // loaded completely. Hence why we use that instead of DOMContentLoaded
-      // Read more: https://thisthat.dev/dom-content-loaded-vs-load/
-      await this.page.reload({ waitUntil: "load" })
+      await this.page.reload()
     }
   }
 
@@ -49,29 +53,19 @@ export class CodeServer {
     // Make sure the editor actually loaded
     // If it's not visible after 5 seconds, something is wrong
     await this.page.waitForLoadState("networkidle")
-    return await this.page.isVisible("div.monaco-workbench", { timeout: 5000 })
+    return await this.page.isVisible(this.editorSelector)
   }
 
   /**
    * Focuses Integrated Terminal
-   * by going to the Application Menu
-   * and clicking View > Terminal
+   * by using "Terminal: Focus Terminal"
+   * from the Command Palette
+   *
+   * This should focus the terminal no matter
+   * if it already has focus and/or is or isn't
+   * visible already.
    */
   async focusTerminal() {
-    // If the terminal is already visible
-    // then we can focus it by hitting the keyboard shortcut
-    const isTerminalVisible = await this.page.isVisible("#terminal")
-    if (isTerminalVisible) {
-      await this.page.keyboard.press(`Control+Backquote`)
-      // TODO fix this
-      // Wait for terminal to receive focus
-      await this.page.waitForSelector("div.terminal.xterm.focus")
-      // Sometimes the terminal reloads
-      // which is why we wait for it twice
-      await this.page.waitForSelector("div.terminal.xterm.focus")
-      return
-    }
-    // Open using the manu
     // Click [aria-label="Application Menu"] div[role="none"]
     await this.page.click('[aria-label="Application Menu"] div[role="none"]')
 
@@ -79,17 +73,19 @@ export class CodeServer {
     await this.page.hover("text=View")
     await this.page.click("text=View")
 
-    // Click text=Terminal
-    await this.page.hover("text=Terminal")
-    await this.page.click("text=Terminal")
+    // Click text=Command Palette
+    await this.page.hover("text=Command Palette")
+    await this.page.click("text=Command Palette")
 
-    // Wait for terminal to receive focus
-    // Sometimes the terminal reloads once or twice
-    // which is why we wait for it to have the focus class
-    await this.page.waitForSelector("div.terminal.xterm.focus")
-    // Sometimes the terminal reloads
-    // which is why we wait for it twice
-    await this.page.waitForSelector("div.terminal.xterm.focus")
+    // Type Terminal: Focus Terminal
+    await this.page.keyboard.type("Terminal: Focus Terminal")
+
+    // Click Terminal: Focus Terminal
+    await this.page.hover("text=Terminal: Focus Terminal")
+    await this.page.click("text=Terminal: Focus Terminal")
+
+    // Wait for terminal textarea to show up
+    await this.page.waitForSelector("textarea.xterm-helper-textarea")
   }
 
   /**

--- a/test/e2e/terminal.test.ts
+++ b/test/e2e/terminal.test.ts
@@ -52,6 +52,8 @@ test.describe("Integrated Terminal", () => {
     await page.waitForLoadState("load")
     await page.keyboard.type(`echo '${testString}' > '${tmpFile}'`)
     await page.keyboard.press("Enter")
+    // It may take a second to process
+    await page.waitForTimeout(1000)
 
     const { stdout } = await output
     expect(stdout).toMatch(testString)


### PR DESCRIPTION
This PR fixes a flaky implementation of the `focusTerminal` method on the `CodeServer` model.  

This was caught after merging into https://github.com/cdr/code-server/pull/3169 `main` and the e2e tests failed [here](https://github.com/cdr/code-server/runs/2442992048?check_suite_focus=true#step:10:6883) 😅

Changes:
- refactor `reloadUntilEditorIsVisible` method. It wasn't waiting for code-server to fully load before reloading. before "Editor became visible after 11 reloads -> "Editor became visible after 1 reload"
- refactor `focusTerminal` method. 

## Before

The `should show the Integrated Terminal` only passed intermittently in Firefox:

```shell
  ✓ CodeServer should show the Integrated Terminal (20s)
  x 3) CodeServer should show the Integrated Terminal (47s)
  x 1) CodeServer should show the Integrated Terminal (47s)
  x 2) CodeServer should show the Integrated Terminal (47s)
  x 4) CodeServer should show the Integrated Terminal (48s)

  1 passed (52s)
  4 failed
    codeServer.test.ts:41:8 › [firefox] CodeServer should show the Integrated Terminal =============
    codeServer.test.ts:41:8 › [firefox] CodeServer should show the Integrated Terminal =============
    codeServer.test.ts:41:8 › [firefox] CodeServer should show the Integrated Terminal =============
    codeServer.test.ts:41:8 › [firefox] CodeServer should show the Integrated Terminal =============

  1) codeServer.test.ts:41:8 › [firefox] CodeServer should show the Integrated Terminal ============
```

https://user-images.githubusercontent.com/3806031/116165230-465eb980-a6b0-11eb-9710-3e6307130afd.mp4

What's happening: it's waiting for the selector `div.terminal.xterm.focus` to be visible, which doesn't happen for some reason and the test times-out.  

![image](https://user-images.githubusercontent.com/3806031/116294170-82475c80-a74c-11eb-8f45-257738eeca2c.png)


## After 

![image](https://user-images.githubusercontent.com/3806031/116292807-f7199700-a74a-11eb-8a1e-89ab3541f9f9.png)

![image](https://user-images.githubusercontent.com/3806031/116315598-99467880-a765-11eb-92c0-0c8c7633cd4d.png)
