### PR TITLE
chore(deps): move yarn to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "stylelint-config-recommended": "^4.0.0",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
-    "wtfnode": "^0.8.4"
+    "wtfnode": "^0.8.4",
+    "yarn": "^1.22.4"
   },
   "resolutions": {
     "safe-buffer": "^5.1.1",
@@ -103,8 +104,7 @@
     "tar-fs": "^2.0.0",
     "tar-stream": "^2.2.0",
     "ws": "^7.2.0",
-    "xdg-basedir": "^4.0.0",
-    "yarn": "^1.22.4"
+    "xdg-basedir": "^4.0.0"
   },
   "bin": {
     "code-server": "out/node/entry.js"


### PR DESCRIPTION
Fixes `yarn` being shipped in our releases removing about ~5mb from the decompressed tar.