### PR TITLE
chore: ignore 15.x @types/node updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       time: "11:00"
     ignore:
       - dependency-name: "@types/node"
-        versions: ["14.x", "13.x"]
+        versions: ["15.x", "14.x", "13.x"]
       - dependency-name: "xdg-basedir"
         # 5.0.0 has breaking changes as they switch to named exports
         # and convert the module to ESM


### PR DESCRIPTION
This PR tells dependabot to ignore 15.x updates to `@types/node`.