### PR TITLE
fix(deps): remove eslint-plugin-jest-playwright

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -15,9 +15,6 @@ extends:
   - plugin:import/recommended
   - plugin:import/typescript
   - plugin:prettier/recommended
-  # Recommended by jest-playwright
-  # https://github.com/playwright-community/jest-playwright#globals
-  - plugin:jest-playwright/recommended
   # Prettier should always be last
   # Removes eslint rules that conflict with prettier.
   - prettier

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint-config-prettier": "^8.1.0",
     "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.18.2",
-    "eslint-plugin-jest-playwright": "^0.2.1",
     "eslint-plugin-prettier": "^3.1.0",
     "leaked-handles": "^5.2.0",
     "parcel-bundler": "^1.12.5",


### PR DESCRIPTION
This PR addresses forgotten work from when we migrated from `jest-playwright` to `playwright-test`.