### PR TITLE
fix(testing): reduce flakiness of terminal.test.ts and use 1 worker for e2e tests

### DIFF
--- a/test/config.ts
+++ b/test/config.ts
@@ -52,6 +52,7 @@ const config: Config = {
   testDir: path.join(__dirname, "e2e"), // Search for tests in this directory.
   timeout: 60000, // Each test is given 60 seconds.
   retries: 3, // Retry failing tests 2 times
+  workers: 1,
 }
 
 if (process.env.CI) {

--- a/test/e2e/terminal.test.ts
+++ b/test/e2e/terminal.test.ts
@@ -50,7 +50,7 @@ test.describe("Integrated Terminal", () => {
     await codeServer.focusTerminal()
 
     await page.waitForLoadState("load")
-    await page.keyboard.type(`echo '${testString}' > '${tmpFile}'`)
+    await page.keyboard.type(`echo ${testString} > ${tmpFile}`)
     await page.keyboard.press("Enter")
     // It may take a second to process
     await page.waitForTimeout(1000)

--- a/yarn.lock
+++ b/yarn.lock
@@ -3141,11 +3141,6 @@ eslint-plugin-import@^2.18.2:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
-eslint-plugin-jest-playwright@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-playwright/-/eslint-plugin-jest-playwright-0.2.1.tgz#8778fee9d5915132a03d94370d3eea0a7ddd08f3"
-  integrity sha512-BicKUJUpVPsLbHN8c5hYaZn6pv8PCMjBGHXUfvlY1p75fh4APVfX2gTK14HuiR8/Bv3fKBQu5MTaqCro4E3OHg==
-
 eslint-plugin-prettier@^3.1.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.0.tgz#cdbad3bf1dbd2b177e9825737fe63b476a08f0c7"


### PR DESCRIPTION
This PR reduces the flakiness of the `terminal.test.ts` and testing overall by using 1 worker. It doesn't eliminate all flakiness but should reduce it.

## Changes
- removes quotes from `echo` command in `terminal.test.ts`
- use 1 worker when running tests
- update `yarn.lock` (forgot to do so in https://github.com/cdr/code-server/pull/3260)

## Screenshots

Running the `terminal.test.ts` 30 times locally (10 for each major browser) and it only failed once -> in chromium. 
![image](https://user-images.githubusercontent.com/3806031/116629985-4b697600-a907-11eb-83fd-3901cadcf796.png)


It's failing because it's either not receiving the full `echo` command or hitting enter before it receives the full command. 

https://user-images.githubusercontent.com/3806031/116630124-8b305d80-a907-11eb-98bc-52ec97b808a9.mp4

## Checklist
- [x] tested locally

I'm going to open up a separate PR to add an additional check for e2e tests to check the connection. https://github.com/cdr/code-server/issues/3270
