### PR TITLE
feat(testing): add test for src/node/constants.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
       "clover"
     ],
     "coveragePathIgnorePatterns": [
-      "out"
+      "/out"
     ],
     "coverageThreshold": {
       "global": {

--- a/test/unit/constants.test.ts
+++ b/test/unit/constants.test.ts
@@ -1,5 +1,4 @@
 import * as fs from "fs"
-import { commit, getPackageJson, version } from "../../src/node/constants"
 import { tmpdir } from "../../test/utils/constants"
 import { loggerModule } from "../utils/helpers"
 
@@ -8,12 +7,14 @@ jest.mock("@coder/logger", () => require("../utils/helpers").loggerModule)
 
 describe("constants", () => {
   describe("getPackageJson", () => {
+    const { getPackageJson } = require("../../src/node/constants")
     afterEach(() => {
       jest.clearAllMocks()
     })
 
     afterAll(() => {
       jest.restoreAllMocks()
+      jest.resetModules()
     })
 
     it("should log a warning if package.json not found", () => {
@@ -36,20 +37,95 @@ describe("constants", () => {
     })
   })
   describe("version", () => {
-    it("should return the package.json version", () => {
-      // Source: https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39#gistcomment-2896416
-      const validSemVar = new RegExp("^(0|[1-9]d*).(0|[1-9]d*).(0|[1-9]d*)")
-      const isValidSemVar = validSemVar.test(version)
-      expect(version).not.toBe(null)
-      expect(isValidSemVar).toBe(true)
+    describe("with package.json.version defined", () => {
+      let mockPackageJson = {
+        name: "mock-code-server",
+        version: "1.0.0",
+      }
+      let version = ""
+
+      beforeEach(() => {
+        jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
+        version = require("../../src/node/constants").version
+      })
+
+      afterEach(() => {
+        jest.resetAllMocks()
+        jest.resetModules()
+      })
+
+      it("should return the package.json version", () => {
+        // Source: https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39#gistcomment-2896416
+        const validSemVar = new RegExp("^(0|[1-9]d*).(0|[1-9]d*).(0|[1-9]d*)")
+        const isValidSemVar = validSemVar.test(version)
+        expect(version).not.toBe(null)
+        expect(isValidSemVar).toBe(true)
+        expect(version).toBe("1.0.0")
+      })
+    })
+    describe("with package.json.version missing", () => {
+      let mockPackageJson = {
+        name: "mock-code-server",
+      }
+      let version = ""
+
+      beforeEach(() => {
+        jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
+        version = require("../../src/node/constants").version
+      })
+
+      afterEach(() => {
+        jest.resetAllMocks()
+        jest.resetModules()
+      })
+
+      it("should return 'development'", () => {
+        expect(version).toBe("development")
+      })
     })
   })
-
   describe("commit", () => {
-    it("should return 'development' if commit is undefined", () => {
-      // In development, the commit is not stored in our package.json
-      // But when we build code-server and release it, it is
-      expect(commit).toBe("development")
+    describe("with package.json.commit defined", () => {
+      let mockPackageJson = {
+        name: "mock-code-server",
+        commit: "f6b2be2838f4afb217c2fd8f03eafedd8d55ef9b",
+      }
+      let commit = ""
+
+      beforeEach(() => {
+        jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
+        commit = require("../../src/node/constants").commit
+      })
+
+      afterEach(() => {
+        jest.resetAllMocks()
+        jest.resetModules()
+      })
+
+      it("should return the package.json.commit", () => {
+        // Source: https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39#gistcomment-2896416
+        expect(commit).toBe("f6b2be2838f4afb217c2fd8f03eafedd8d55ef9b")
+      })
+    })
+    describe("with package.json.commit missing", () => {
+      let mockPackageJson = {
+        name: "mock-code-server",
+      }
+      let commit = ""
+
+      beforeEach(() => {
+        jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
+        commit = require("../../src/node/constants").commit
+      })
+
+      afterEach(() => {
+        jest.resetAllMocks()
+        jest.resetModules()
+      })
+
+      it("should return 'development'", () => {
+        expect(commit).toBe("development")
+      })
     })
   })
 })

--- a/test/unit/constants.test.ts
+++ b/test/unit/constants.test.ts
@@ -6,126 +6,86 @@ import { loggerModule } from "../utils/helpers"
 jest.mock("@coder/logger", () => require("../utils/helpers").loggerModule)
 
 describe("constants", () => {
-  describe("getPackageJson", () => {
+  beforeAll(() => {
+    jest.clearAllMocks()
+    jest.resetModules()
+  })
+  describe("with package.json defined", () => {
     const { getPackageJson } = require("../../src/node/constants")
-    afterEach(() => {
-      jest.clearAllMocks()
+    let mockPackageJson = {
+      name: "mock-code-server",
+      description: "Run VS Code on a remote server.",
+      repository: "https://github.com/cdr/code-server",
+      version: "1.0.0",
+      commit: "f6b2be2838f4afb217c2fd8f03eafedd8d55ef9b",
+    }
+    let version = ""
+    let commit = ""
+
+    beforeEach(() => {
+      jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
+      commit = require("../../src/node/constants").commit
+      version = require("../../src/node/constants").version
     })
 
     afterAll(() => {
-      jest.restoreAllMocks()
+      jest.clearAllMocks()
       jest.resetModules()
     })
 
-    it("should log a warning if package.json not found", () => {
-      const expectedErrorMessage = "Cannot find module './package.json' from 'src/node/constants.ts'"
-
-      getPackageJson("./package.json")
-
-      expect(loggerModule.logger.warn).toHaveBeenCalled()
-      expect(loggerModule.logger.warn).toHaveBeenCalledWith(expectedErrorMessage)
+    it("should provide the commit", () => {
+      expect(commit).toBe("f6b2be2838f4afb217c2fd8f03eafedd8d55ef9b")
     })
 
-    it("should find the package.json", () => {
-      // the function calls require from src/node/constants
-      // so to get the root package.json we need to use ../../
-      const packageJson = getPackageJson("../../package.json")
-      expect(Object.keys(packageJson).length).toBeGreaterThan(0)
-      expect(packageJson.name).toBe("code-server")
-      expect(packageJson.description).toBe("Run VS Code on a remote server.")
-      expect(packageJson.repository).toBe("https://github.com/cdr/code-server")
+    it("should return the package.json version", () => {
+      expect(version).toBe(mockPackageJson.version)
     })
-  })
-  describe("version", () => {
-    describe("with package.json.version defined", () => {
-      let mockPackageJson = {
-        name: "mock-code-server",
-        version: "1.0.0",
-      }
-      let version = ""
 
-      beforeEach(() => {
-        jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
-        version = require("../../src/node/constants").version
+    describe("getPackageJson", () => {
+      it("should log a warning if package.json not found", () => {
+        const expectedErrorMessage = "Cannot find module './package.json' from 'src/node/constants.ts'"
+
+        getPackageJson("./package.json")
+
+        expect(loggerModule.logger.warn).toHaveBeenCalled()
+        expect(loggerModule.logger.warn).toHaveBeenCalledWith(expectedErrorMessage)
       })
 
-      afterEach(() => {
-        jest.resetAllMocks()
-        jest.resetModules()
-      })
-
-      it("should return the package.json version", () => {
-        // Source: https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39#gistcomment-2896416
-        const validSemVar = new RegExp("^(0|[1-9]d*).(0|[1-9]d*).(0|[1-9]d*)")
-        const isValidSemVar = validSemVar.test(version)
-        expect(version).not.toBe(null)
-        expect(isValidSemVar).toBe(true)
-        expect(version).toBe("1.0.0")
-      })
-    })
-    describe("with package.json.version missing", () => {
-      let mockPackageJson = {
-        name: "mock-code-server",
-      }
-      let version = ""
-
-      beforeEach(() => {
-        jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
-        version = require("../../src/node/constants").version
-      })
-
-      afterEach(() => {
-        jest.resetAllMocks()
-        jest.resetModules()
-      })
-
-      it("should return 'development'", () => {
-        expect(version).toBe("development")
+      it("should find the package.json", () => {
+        // the function calls require from src/node/constants
+        // so to get the root package.json we need to use ../../
+        const packageJson = getPackageJson("../../package.json")
+        expect(Object.keys(packageJson).length).toBeGreaterThan(0)
+        expect(packageJson.name).toBe("mock-code-server")
+        expect(packageJson.description).toBe("Run VS Code on a remote server.")
+        expect(packageJson.repository).toBe("https://github.com/cdr/code-server")
       })
     })
   })
-  describe("commit", () => {
-    describe("with package.json.commit defined", () => {
-      let mockPackageJson = {
-        name: "mock-code-server",
-        commit: "f6b2be2838f4afb217c2fd8f03eafedd8d55ef9b",
-      }
-      let commit = ""
 
-      beforeEach(() => {
-        jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
-        commit = require("../../src/node/constants").commit
-      })
+  describe("with incomplete package.json", () => {
+    let mockPackageJson = {
+      name: "mock-code-server",
+    }
+    let version = ""
+    let commit = ""
 
-      afterEach(() => {
-        jest.resetAllMocks()
-        jest.resetModules()
-      })
-
-      it("should return the package.json.commit", () => {
-        // Source: https://gist.github.com/jhorsman/62eeea161a13b80e39f5249281e17c39#gistcomment-2896416
-        expect(commit).toBe("f6b2be2838f4afb217c2fd8f03eafedd8d55ef9b")
-      })
+    beforeEach(() => {
+      jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
+      version = require("../../src/node/constants").version
+      commit = require("../../src/node/constants").commit
     })
-    describe("with package.json.commit missing", () => {
-      let mockPackageJson = {
-        name: "mock-code-server",
-      }
-      let commit = ""
 
-      beforeEach(() => {
-        jest.mock("../../package.json", () => mockPackageJson, { virtual: true })
-        commit = require("../../src/node/constants").commit
-      })
+    afterEach(() => {
+      jest.clearAllMocks()
+      jest.resetModules()
+    })
 
-      afterEach(() => {
-        jest.resetAllMocks()
-        jest.resetModules()
-      })
-
-      it("should return 'development'", () => {
-        expect(commit).toBe("development")
-      })
+    it("version should return 'development'", () => {
+      expect(version).toBe("development")
+    })
+    it("commit should return 'development'", () => {
+      expect(commit).toBe("development")
     })
   })
 })


### PR DESCRIPTION
This PR adds additional testing for `src/node/constants.ts`, specifically checking that both `commit` and `version` return the correct values when defined in and missing from `package.json`.

- update `coveragePathIgnorePatterns` to `/out` (so that we collect coverage for `src/node/routes`
- add tests for `src/node/constants.ts`

## Screenshot
![image](https://user-images.githubusercontent.com/3806031/117222546-857fbf80-adc0-11eb-9cb3-34272e08d4f0.png)
