### PR TITLE
fix(ci): update trivy-action to use master

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -423,7 +423,7 @@ jobs:
 
       - name: Run Trivy vulnerability scanner in image mode
         # Commit SHA for v0.0.14
-        uses: aquasecurity/trivy-action@b38389f8efef9798810fe0c5b5096ac198cffd54
+        uses: aquasecurity/trivy-action@master
         with:
           input: "./release-images/code-server-amd64-*.tar"
           scan-type: "image"


### PR DESCRIPTION
## Problem

In `ci.yaml`, we have a job called `trivy-scan-repo` which scans the repo for vulnerabilities using `trivy-action`. It then uploads those results to the GitHub Security tab. It's failing due to this error (see [logs](https://github.com/cdr/code-server/pull/3296/checks?check_run_id=2512446010#step:5:157)):
```logs
Error: Unable to upload "trivy-repo-results.sarif" as it is not valid SARIF:
- instance.runs[0].tool.driver.rules contains duplicate item
```

[This issue](https://github.com/aquasecurity/trivy-action/issues/22) was filed back in December 2020 and fixed in `trivy on March 23 (see [PR](https://github.com/aquasecurity/trivy/pull/913)).

According to the maintainers, this fix should be in `trivy-action` because:
> Trivy Action uses the latest released version of Trivy https://github.com/aquasecurity/trivy-action/blob/master/Dockerfile#L1
> Trivy recently had a new release which includes this fix so by the virtue of that the new Trivy Action will also have it.

Reference: https://github.com/aquasecurity/trivy-action/issues/22#issuecomment-832966373


UPDATE: they're looking into it
Reference: https://github.com/aquasecurity/trivy-action/issues/22#issuecomment-832994212