### PR TITLE
fix(socket): use xdgBasedir.runtime instead of tmp

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,7 +2,7 @@
 Please link to the issue this PR solves.
 If there is no existing issue, please first create one unless the fix is minor.
 
-Please make sure the base of your PR is the master branch!
+Please make sure the base of your PR is the default branch!
 -->
 
 ## Checklist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ VS Code v1.56
 ### Development
 
 - chore: ignore updates to microsoft/playwright-github-action
+- fix(socket): use xdgBasedir.runtime instead of tmp #3304 @jsjoeio
 
 ## 3.10.0
 

--- a/src/node/socket.ts
+++ b/src/node/socket.ts
@@ -4,8 +4,7 @@ import * as path from "path"
 import * as tls from "tls"
 import { Emitter } from "../common/emitter"
 import { generateUuid } from "../common/util"
-import { tmpdir } from "./constants"
-import { canConnect } from "./util"
+import { canConnect, paths } from "./util"
 
 /**
  * Provides a way to proxy a TLS socket. Can be used when you need to pass a
@@ -13,7 +12,7 @@ import { canConnect } from "./util"
  */
 export class SocketProxyProvider {
   private readonly onProxyConnect = new Emitter<net.Socket>()
-  private proxyPipe = path.join(tmpdir, "tls-proxy")
+  private proxyPipe = path.join(paths.runtime, "tls-proxy")
   private _proxyServer?: Promise<net.Server>
   private readonly proxyTimeout = 5000
 
@@ -76,7 +75,10 @@ export class SocketProxyProvider {
       this._proxyServer = this.findFreeSocketPath(this.proxyPipe)
         .then((pipe) => {
           this.proxyPipe = pipe
-          return Promise.all([fs.mkdir(tmpdir, { recursive: true }), fs.rmdir(this.proxyPipe, { recursive: true })])
+          return Promise.all([
+            fs.mkdir(paths.runtime, { recursive: true }),
+            fs.rmdir(this.proxyPipe, { recursive: true }),
+          ])
         })
         .then(() => {
           return new Promise((resolve) => {

--- a/src/node/socket.ts
+++ b/src/node/socket.ts
@@ -76,7 +76,7 @@ export class SocketProxyProvider {
         .then((pipe) => {
           this.proxyPipe = pipe
           return Promise.all([
-            fs.mkdir(paths.runtime, { recursive: true }),
+            fs.mkdir(path.dirname(this.proxyPipe), { recursive: true }),
             fs.rmdir(this.proxyPipe, { recursive: true }),
           ])
         })

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -7,10 +7,12 @@ import * as os from "os"
 import * as path from "path"
 import * as util from "util"
 import xdgBasedir from "xdg-basedir"
+import { tmpdir } from "./constants"
 
 interface Paths {
   data: string
   config: string
+  runtime: string
 }
 
 export const paths = getEnvPaths()
@@ -20,12 +22,15 @@ export const paths = getEnvPaths()
  * On MacOS this function gets the standard XDG directories instead of using the native macOS
  * ones. Most CLIs do this as in practice only GUI apps use the standard macOS directories.
  */
-function getEnvPaths(): Paths {
+export function getEnvPaths(): Paths {
   let paths: Paths
   if (process.platform === "win32") {
-    paths = envPaths("code-server", {
-      suffix: "",
-    })
+    paths = {
+      ...envPaths("code-server", {
+        suffix: "",
+      }),
+      runtime: tmpdir,
+    }
   } else {
     if (xdgBasedir.data === undefined || xdgBasedir.config === undefined) {
       throw new Error("No home folder?")
@@ -33,6 +38,7 @@ function getEnvPaths(): Paths {
     paths = {
       data: path.join(xdgBasedir.data, "code-server"),
       config: path.join(xdgBasedir.config, "code-server"),
+      runtime: xdgBasedir.runtime ? path.join(xdgBasedir.runtime, "code-server") : tmpdir,
     }
   }
 

--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -1,0 +1,10 @@
+import { getEnvPaths } from "../../../src/node/util"
+
+describe("getEnvPaths", () => {
+  it("should return an object with the data, config and runtime path", () => {
+    const actualPaths = getEnvPaths()
+    expect(actualPaths.hasOwnProperty("data")).toBe(true)
+    expect(actualPaths.hasOwnProperty("config")).toBe(true)
+    expect(actualPaths.hasOwnProperty("runtime")).toBe(true)
+  })
+})

--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -1,10 +1,147 @@
-import { getEnvPaths } from "../../../src/node/util"
-
 describe("getEnvPaths", () => {
-  it("should return an object with the data, config and runtime path", () => {
-    const actualPaths = getEnvPaths()
-    expect(actualPaths.hasOwnProperty("data")).toBe(true)
-    expect(actualPaths.hasOwnProperty("config")).toBe(true)
-    expect(actualPaths.hasOwnProperty("runtime")).toBe(true)
+  describe("on darwin", () => {
+    let ORIGINAL_PLATFORM = ""
+
+    beforeAll(() => {
+      ORIGINAL_PLATFORM = process.platform
+
+      Object.defineProperty(process, "platform", {
+        value: "darwin",
+      })
+    })
+
+    beforeEach(() => {
+      jest.resetModules()
+      jest.mock("env-paths", () => {
+        return () => ({
+          data: "/home/envPath/.local/share",
+          config: "/home/envPath/.config",
+          temp: "/tmp/envPath/runtime",
+        })
+      })
+    })
+
+    afterAll(() => {
+      // Restore old platform
+
+      Object.defineProperty(process, "platform", {
+        value: ORIGINAL_PLATFORM,
+      })
+    })
+
+    it("should return the env paths using xdgBasedir", () => {
+      jest.mock("xdg-basedir", () => ({
+        data: "/home/usr/.local/share",
+        config: "/home/usr/.config",
+        runtime: "/tmp/runtime",
+      }))
+      const getEnvPaths = require("../../../src/node/util").getEnvPaths
+      const envPaths = getEnvPaths()
+
+      expect(envPaths.data).toEqual("/home/usr/.local/share/code-server")
+      expect(envPaths.config).toEqual("/home/usr/.config/code-server")
+      expect(envPaths.runtime).toEqual("/tmp/runtime/code-server")
+    })
+
+    it("should return the env paths using envPaths when xdgBasedir is undefined", () => {
+      jest.mock("xdg-basedir", () => ({}))
+      const getEnvPaths = require("../../../src/node/util").getEnvPaths
+      const envPaths = getEnvPaths()
+
+      expect(envPaths.data).toEqual("/home/envPath/.local/share")
+      expect(envPaths.config).toEqual("/home/envPath/.config")
+      expect(envPaths.runtime).toEqual("/tmp/envPath/runtime")
+    })
+  })
+  describe("on win32", () => {
+    let ORIGINAL_PLATFORM = ""
+
+    beforeAll(() => {
+      ORIGINAL_PLATFORM = process.platform
+
+      Object.defineProperty(process, "platform", {
+        value: "win32",
+      })
+    })
+
+    beforeEach(() => {
+      jest.resetModules()
+      jest.mock("env-paths", () => {
+        return () => ({
+          data: "/windows/envPath/.local/share",
+          config: "/windows/envPath/.config",
+          temp: "/tmp/envPath/runtime",
+        })
+      })
+    })
+
+    afterAll(() => {
+      // Restore old platform
+
+      Object.defineProperty(process, "platform", {
+        value: ORIGINAL_PLATFORM,
+      })
+    })
+
+    it("should return the env paths using envPaths", () => {
+      const getEnvPaths = require("../../../src/node/util").getEnvPaths
+      const envPaths = getEnvPaths()
+
+      expect(envPaths.data).toEqual("/windows/envPath/.local/share")
+      expect(envPaths.config).toEqual("/windows/envPath/.config")
+      expect(envPaths.runtime).toEqual("/tmp/envPath/runtime")
+    })
+  })
+  describe("on other platforms", () => {
+    let ORIGINAL_PLATFORM = ""
+
+    beforeAll(() => {
+      ORIGINAL_PLATFORM = process.platform
+
+      Object.defineProperty(process, "platform", {
+        value: "linux",
+      })
+    })
+
+    beforeEach(() => {
+      jest.resetModules()
+      jest.mock("env-paths", () => {
+        return () => ({
+          data: "/linux/envPath/.local/share",
+          config: "/linux/envPath/.config",
+          temp: "/tmp/envPath/runtime",
+        })
+      })
+    })
+
+    afterAll(() => {
+      // Restore old platform
+
+      Object.defineProperty(process, "platform", {
+        value: ORIGINAL_PLATFORM,
+      })
+    })
+
+    it("should return the runtime using xdgBasedir if it exists", () => {
+      jest.mock("xdg-basedir", () => ({
+        runtime: "/tmp/runtime",
+      }))
+      const getEnvPaths = require("../../../src/node/util").getEnvPaths
+      const envPaths = getEnvPaths()
+
+      expect(envPaths.data).toEqual("/linux/envPath/.local/share")
+      expect(envPaths.config).toEqual("/linux/envPath/.config")
+      expect(envPaths.runtime).toEqual("/tmp/runtime/code-server")
+    })
+
+    it("should return the env paths using envPaths when xdgBasedir is undefined", () => {
+      jest.mock("xdg-basedir", () => ({}))
+      const getEnvPaths = require("../../../src/node/util").getEnvPaths
+      const envPaths = getEnvPaths()
+
+      expect(envPaths.data).toEqual("/linux/envPath/.local/share")
+      expect(envPaths.config).toEqual("/linux/envPath/.config")
+      expect(envPaths.runtime).toEqual("/tmp/envPath/runtime")
+    })
   })
 })


### PR DESCRIPTION
This PR fixes this issue:
```shell
discarding socket connection: EACCES: permission denied, unlink '/tmp/code-server/tls-proxy'
```

by using the `xdgBasedir.runtime` path instead of `/tmp/code-server/tls-proxy`.

## Changes
- update pr template to say default branch
- add `runtime` to `getEnvPaths`
- add test for `getEnvPaths`
- remove use of `tmpdir` in `socket.ts`

  
refactor: use paths.runtime in socket proxyPipe

## Screenshots
![image](https://user-images.githubusercontent.com/3806031/117736597-d91d4f00-b1ac-11eb-93fb-6215e646a6f7.png)



## Checklist
- [x] tested locally
- [x] added a test
- [x] updated CHANGELOG

Fixes #2200