### PR TITLE
Check the logged user instead of $USER

### DIFF
--- a/ci/release-image/entrypoint.sh
+++ b/ci/release-image/entrypoint.sh
@@ -5,14 +5,14 @@ set -eu
 # Otherwise the current container UID may not exist in the passwd database.
 eval "$(fixuid -q)"
 
-if [ "${DOCKER_USER-}" ] && [ "$DOCKER_USER" != "$USER" ]; then
+USER="$DOCKER_USER"
+
+if [ "${DOCKER_USER-}" ] && [ "$DOCKER_USER" != "$(whoami)" ]; then
   echo "$DOCKER_USER ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/nopasswd >/dev/null
   # Unfortunately we cannot change $HOME as we cannot move any bind mounts
   # nor can we bind mount $HOME into a new home as that requires a privileged container.
   sudo usermod --login "$DOCKER_USER" coder
   sudo groupmod -n "$DOCKER_USER" coder
-
-  USER="$DOCKER_USER"
 
   sudo sed -i "/coder/d" /etc/sudoers.d/nopasswd
 fi

--- a/ci/release-image/entrypoint.sh
+++ b/ci/release-image/entrypoint.sh
@@ -5,16 +5,17 @@ set -eu
 # Otherwise the current container UID may not exist in the passwd database.
 eval "$(fixuid -q)"
 
-USER="$DOCKER_USER"
+if [ "${DOCKER_USER-}" ]; then
+  USER="$DOCKER_USER"
+  if [ "$DOCKER_USER" != "$(whoami)" ]; then
+    echo "$DOCKER_USER ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/nopasswd >/dev/null
+    # Unfortunately we cannot change $HOME as we cannot move any bind mounts
+    # nor can we bind mount $HOME into a new home as that requires a privileged container.
+    sudo usermod --login "$DOCKER_USER" coder
+    sudo groupmod -n "$DOCKER_USER" coder
 
-if [ "${DOCKER_USER-}" ] && [ "$DOCKER_USER" != "$(whoami)" ]; then
-  echo "$DOCKER_USER ALL=(ALL) NOPASSWD:ALL" | sudo tee -a /etc/sudoers.d/nopasswd >/dev/null
-  # Unfortunately we cannot change $HOME as we cannot move any bind mounts
-  # nor can we bind mount $HOME into a new home as that requires a privileged container.
-  sudo usermod --login "$DOCKER_USER" coder
-  sudo groupmod -n "$DOCKER_USER" coder
-
-  sudo sed -i "/coder/d" /etc/sudoers.d/nopasswd
+    sudo sed -i "/coder/d" /etc/sudoers.d/nopasswd
+  fi
 fi
 
 dumb-init /usr/bin/code-server "$@"


### PR DESCRIPTION
Given that `sudo usermod --login "$DOCKER_USER" coder` and `sudo groupmod -n "$DOCKER_USER" coder` modify the container's disk it'll persist across restarts, but environment variables will be reset to whatever state they had at the end of `Dockerfile`. In this case, `$USER` is set to `coder`, so this branch will always be true.

By checking with the output of `whoami`, which gets it's information from `/etc/passwd`, we make sure to get the real logged user and not the one defined by $USER.

We also move `USER="$DOCKER_USER"` out of the branch, since we always want this to happen at entry-point. If we don't do this assignment, $USER will contain `coder` upon restart.

Fixes #2767.