### PR TITLE
release: 3.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # code-server &middot; [!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
 
 [![codecov](https://codecov.io/gh/cdr/code-server/branch/main/graph/badge.svg?token=5iM9farjnC)](https://codecov.io/gh/cdr/code-server)
-[![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.9.3/docs)
+[![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.10.0/docs)
 
 Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and access it in the browser.
 

--- a/ci/build/release-github-assets.sh
+++ b/ci/build/release-github-assets.sh
@@ -12,9 +12,7 @@ main() {
 
   download_artifact release-packages ./release-packages
   local assets=(./release-packages/code-server*"$VERSION"*{.tar.gz,.deb,.rpm})
-  for i in "${!assets[@]}"; do
-    assets[$i]="--attach=${assets[$i]}"
-  done
+
   EDITOR=true gh release upload "v$VERSION" "${assets[@]}"
 }
 

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.9.3
+appVersion: 3.10.0

--- a/ci/helm-chart/README.md
+++ b/ci/helm-chart/README.md
@@ -1,6 +1,6 @@
 # code-server
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.10.0](https://img.shields.io/badge/AppVersion-3.10.0-informational?style=flat-square)
 
 [code-server](https://github.com/cdr/code-server) code-server is VS Code running
 on a remote server, accessible through the browser.
@@ -72,7 +72,7 @@ and their default values.
 | hostnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"codercom/code-server"` |  |
-| image.tag | string | `"3.9.3"` |  |
+| image.tag | string | `"3.10.0"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '3.9.3'
+  tag: '3.10.0'
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -54,7 +54,7 @@ arch() {
 # https://developer.github.com/v3/actions/workflow-runs/#list-workflow-runs
 get_artifacts_url() {
   local artifacts_url
-  local workflow_runs_url="repos/:owner/:repo/actions/workflows/ci.yaml/runs?status=success&event=pull_request"
+  local workflow_runs_url="repos/:owner/:repo/actions/workflows/ci.yaml/runs?event=pull_request"
   # For releases, we look for run based on the branch name v$code_server_version
   # example: v3.10.0
   local version_branch="v$VERSION"

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -56,7 +56,7 @@ get_artifacts_url() {
   local artifacts_url
   local workflow_runs_url="repos/:owner/:repo/actions/workflows/ci.yaml/runs?status=success&event=pull_request"
   # For releases, we look for run based on the branch name v$code_server_version
-  # example: v3.9.3
+  # example: v3.10.0
   local version_branch="v$VERSION"
   artifacts_url=$(gh api "$workflow_runs_url" | jq -r ".workflow_runs[] | select(.head_branch == \"$version_branch\") | .artifacts_url" | head -n 1)
   if [[ -z "$artifacts_url" ]]; then

--- a/docs/install.md
+++ b/docs/install.md
@@ -92,8 +92,8 @@ NOTE: The standalone arm64 .deb does not support Ubuntu <16.04.
 Please upgrade or [build with yarn](#yarn-npm).
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.9.3/code-server_3.9.3_amd64.deb
-sudo dpkg -i code-server_3.9.3_amd64.deb
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.10.0/code-server_3.10.0_amd64.deb
+sudo dpkg -i code-server_3.10.0_amd64.deb
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -104,8 +104,8 @@ NOTE: The standalone arm64 .rpm does not support CentOS 7.
 Please upgrade or [build with yarn](#yarn-npm).
 
 ```bash
-curl -fOL https://github.com/cdr/code-server/releases/download/v3.9.3/code-server-3.9.3-amd64.rpm
-sudo rpm -i code-server-3.9.3-amd64.rpm
+curl -fOL https://github.com/cdr/code-server/releases/download/v3.10.0/code-server-3.10.0-amd64.rpm
+sudo rpm -i code-server-3.10.0-amd64.rpm
 sudo systemctl enable --now code-server@$USER
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
@@ -179,10 +179,10 @@ Here is an example script for installing and using a standalone `code-server` re
 
 ```bash
 mkdir -p ~/.local/lib ~/.local/bin
-curl -fL https://github.com/cdr/code-server/releases/download/v3.9.3/code-server-3.9.3-linux-amd64.tar.gz \
+curl -fL https://github.com/cdr/code-server/releases/download/v3.10.0/code-server-3.10.0-linux-amd64.tar.gz \
   | tar -C ~/.local/lib -xz
-mv ~/.local/lib/code-server-3.9.3-linux-amd64 ~/.local/lib/code-server-3.9.3
-ln -s ~/.local/lib/code-server-3.9.3/bin/code-server ~/.local/bin/code-server
+mv ~/.local/lib/code-server-3.10.0-linux-amd64 ~/.local/lib/code-server-3.10.0
+ln -s ~/.local/lib/code-server-3.10.0/bin/code-server ~/.local/bin/code-server
 PATH="~/.local/bin:$PATH"
 code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml

--- a/install.sh
+++ b/install.sh
@@ -419,7 +419,7 @@ install_npm() {
   echoh
   echoerr "Please install npm or yarn to install code-server!"
   echoerr "You will need at least node v12 and a few C dependencies."
-  echoerr "See the docs https://github.com/cdr/code-server/blob/v3.9.3/docs/install.md#yarn-npm"
+  echoerr "See the docs https://github.com/cdr/code-server/blob/v3.10.0/docs/install.md#yarn-npm"
   exit 1
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "3.9.3",
+  "version": "3.10.0",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/cdr/code-server",
   "bugs": {


### PR DESCRIPTION
<!-- Note: this variable $CODE_SERVER_VERSION_TO_UPDATE will be set when you run the release-prep.sh script with `yarn release:prep` -->

This PR is to generate a new release of `code-server` at `$CODE_SERVER_VERSION_TO_UPDATE`

## Screenshot

![VSCode 1.56/code-server 3.10](https://user-images.githubusercontent.com/19502779/117723763-6d64d180-b200-11eb-9e75-b4be613506f1.png)

## TODOs

- [x] test locally
- [x] upload assets to draft release
- [x] test one of the release packages locally
- [x] double-check github release tag is the commit with artifacts (_note gets messed up after uploading assets_)
- [x] publish release
- [x] merge PR
- [x] update the homebrew package
- [ ] update the AUR package