### PR TITLE
chore: ignore updates to microsoft/playwright-github-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       # release tag, so handle updates manually
       - dependency-name: "actions/*"
       - dependency-name: "github/codeql-action/*"
+      - dependency-name: "microsoft/playwright-github-action"
 
   - package-ecosystem: "npm"
     directory: "/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@ VS Code v1.56
 
 ### Development
 
-- item
+- chore: ignore updates to microsoft/playwright-github-action
 
 ## 3.10.0
 


### PR DESCRIPTION
Microsoft publishes updates to this action using the same scheme
as GitHub, where the v1 tag is updated to the latest release of
the 1.0 series. Therefore, we can manage updates manually.