### PR TITLE
fix(ci): re-enable trivy-scan-repo

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -466,16 +466,12 @@ jobs:
   # codeql/upload-sarif action per job
   trivy-scan-repo:
     runs-on: ubuntu-20.04
-    # NOTE@jsjoeio 5/10/2021
-    # Disabling until fixed upstream
-    # See: https://github.com/aquasecurity/trivy-action/issues/22#issuecomment-833768084
-    if: "1 == 2"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Trivy vulnerability scanner in repo mode
-        #Commit SHA for v0.0.14
-        uses: aquasecurity/trivy-action@341f810bd602419f966a081da3f4debedc3e5c8e
+        #Commit SHA for v0.0.15
+        uses: aquasecurity/trivy-action@9789b6ae3b29487541292242e416cd89e4e54874
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -446,8 +446,8 @@ jobs:
           path: ./release-images
 
       - name: Run Trivy vulnerability scanner in image mode
-        # Commit SHA for v0.0.14
-        uses: aquasecurity/trivy-action@341f810bd602419f966a081da3f4debedc3e5c8e
+        # Commit SHA for v0.0.17
+        uses: aquasecurity/trivy-action@dba83feec810c70bacbc4bead308ae1e466c572b
         with:
           input: "./release-images/code-server-amd64-*.tar"
           scan-type: "image"
@@ -470,8 +470,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Trivy vulnerability scanner in repo mode
-        #Commit SHA for v0.0.15
-        uses: aquasecurity/trivy-action@9789b6ae3b29487541292242e416cd89e4e54874
+        #Commit SHA for v0.0.17
+        uses: aquasecurity/trivy-action@dba83feec810c70bacbc4bead308ae1e466c572b
         with:
           scan-type: "fs"
           scan-ref: "."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ VS Code v1.56
 
 - chore: ignore updates to microsoft/playwright-github-action
 - fix(socket): use xdgBasedir.runtime instead of tmp #3304 @jsjoeio
+- fix(ci): re-enable trivy-scan-repo #3368 @jsjoeio
 
 ## 3.10.0
 


### PR DESCRIPTION
This PR re-enables `trivy-scan-repo` now that it's been fixed upstream.

Reference: https://github.com/aquasecurity/trivy-action/issues/22#issuecomment-839948770

## Checklist

- [x] updated `CHANGELOG.md`
