### PR TITLE
Override existing asar symlink in postinstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ VS Code v1.56
 ### Bug Fixes
 
 - fix: Check the logged user instead of $USER #3330 @videlanicolas
+- fix: Fix broken node_modules.asar symlink in npm package #3355 @code-asher
 
 ### Documentation
 

--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -56,18 +56,21 @@ main() {
   fi
 }
 
+# This is a copy of symlink_asar in ../lib.sh. Look there for details.
+symlink_asar() {
+  rm -f node_modules.asar
+  if [ "${WINDIR-}" ]; then
+    mklink /J node_modules.asar node_modules
+  else
+    ln -s node_modules node_modules.asar
+  fi
+}
+
 vscode_yarn() {
   cd lib/vscode
   yarn --production --frozen-lockfile
 
-  # This is a copy of symlink_asar in ../lib.sh. Look there for details.
-  if [ ! -e node_modules.asar ]; then
-    if [ "${WINDIR-}" ]; then
-      mklink /J node_modules.asar node_modules
-    else
-      ln -s node_modules node_modules.asar
-    fi
-  fi
+  symlink_asar
 
   cd extensions
   yarn --production --frozen-lockfile

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -112,13 +112,12 @@ RELEASE_PATH="${RELEASE_PATH-release}"
 # Code itself but also extensions will look specifically in this directory for
 # files (like the ripgrep binary or the oniguruma wasm).
 symlink_asar() {
-  if [ ! -L node_modules.asar ]; then
-    if [ "${WINDIR-}" ]; then
-      # mklink takes the link name first.
-      mklink /J node_modules.asar node_modules
-    else
-      # ln takes the link name second.
-      ln -s node_modules node_modules.asar
-    fi
+  rm -f node_modules.asar
+  if [ "${WINDIR-}" ]; then
+    # mklink takes the link name first.
+    mklink /J node_modules.asar node_modules
+  else
+    # ln takes the link name second.
+    ln -s node_modules node_modules.asar
   fi
 }


### PR DESCRIPTION
This ensures the link is correct. Should fix #3355.