### PR TITLE
docs(maintaining): add merge strategies section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ VS Code v1.56
 
 - docs(install): add raspberry pi section #3376 @jsjoeio
 - docs(maintaining): add pull requests section #3378 @jsjoeio
+- docs(maintaining): add merge strategies section #3379 @jsjoeio
 
 ### Development
 

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -9,6 +9,7 @@
     - [Project Boards](#project-boards)
   - [Versioning](#versioning)
   - [Pull Requests](#pull-requests)
+    - [Merge Strategies](#merge-strategies)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -70,3 +71,7 @@ The code-server project follows traditional [semantic versioning](ttps://semver.
 Ideally, every PR should fix an issue. If it doesn't, make sure it's associated with a version milestone.
 
 If a PR does fix an issue, don't add it to the version milestone. Otherwise, the version milestone will have duplicate information: the issue & the PR fixing the issue.
+
+### Merge Strategies
+
+For most things, we recommend "Squash and Merge". If you're updating `lib/vscode`, we suggest using the "Rebase and Merge" strategy. There may be times where "Create a merge commit" makes sense as well. Use your best judgement.


### PR DESCRIPTION
This PR updates `MAINTAINING.md` with "Merge Strategies" providing some recommendations.
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the master branch!
-->

## Checklist

- [x] updated `CHANGELOG.md`
