### PR TITLE
Add socket type to websocket connection query (regression)

### DIFF
--- a/lib/vscode/src/vs/platform/remote/common/remoteAgentConnection.ts
+++ b/lib/vscode/src/vs/platform/remote/common/remoteAgentConnection.ts
@@ -229,7 +229,9 @@ async function connectToRemoteExtensionHostAgent(options: ISimpleConnectionOptio
 
 	let socket: ISocket;
 	try {
-		socket = await createSocket(options.logService, options.socketFactory, options.host, options.port, `reconnectionToken=${options.reconnectionToken}&reconnection=${options.reconnectionProtocol ? 'true' : 'false'}`, timeoutCancellationToken);
+		// NOTE@coder: Add connection type to the socket. This is so they can be
+		// distinguished by the backend.
+		socket = await createSocket(options.logService, options.socketFactory, options.host, options.port, `type=${connectionTypeToString(connectionType)}&reconnectionToken=${options.reconnectionToken}&reconnection=${options.reconnectionProtocol ? 'true' : 'false'}`, timeoutCancellationToken);
 	} catch (error) {
 		options.logService.error(`${logPrefix} socketFactory.connect() failed or timed out. Error:`);
 		options.logService.error(error);


### PR DESCRIPTION
This was added a long time ago but accidentally lost when we reverted
the retry changes to this file after one of the VS Code updates that
added their own retry (we reverted everything not realizing we had other
unrelated changes in here).

This is definitely one downside to the subtree over patches but I added 
a note to help ensure we notice the change in case something similar 
happens again.