### PR TITLE
fix: use correct command to Open Folder on Welcome page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ VS Code v1.56.1
 - fix: Check the logged user instead of $USER #3330 @videlanicolas
 - fix: Fix broken node_modules.asar symlink in npm package #3355 @code-asher
 - fix: Update cloud agent to fix version issue #3342 @oxy
+- fix: use correct command to Open Folder on Welcome page #3437 @jsjoeio
 
 ### Documentation
 

--- a/lib/vscode/src/vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page.ts
+++ b/lib/vscode/src/vs/workbench/contrib/welcome/page/browser/vs_code_welcome_page.ts
@@ -20,7 +20,7 @@ export default () => `
 					<h2 class="caption">${escape(localize('welcomePage.start', "Start"))}</h2>
 					<ul>
 						<li><a href="command:workbench.action.files.newUntitledFile">${escape(localize('welcomePage.newFile', "New file"))}</a></li>
-						<li class="mac-only"><a href="command:workbench.action.files.openFileFolder">${escape(localize('welcomePage.openFolder', "Open folder..."))}</a> or <a href="command:git.clone">${escape(localize('welcomePage.gitClone', "clone repository..."))}</a></li>
+						<li class="mac-only"><a href="command:workbench.action.files.openFolder">${escape(localize('welcomePage.openFolder', "Open folder..."))}</a> or <a href="command:git.clone">${escape(localize('welcomePage.gitClone', "clone repository..."))}</a></li>
 						<li class="windows-only linux-only"><a href="command:workbench.action.files.openFolder">${escape(localize('welcomePage.openFolder', "Open folder..."))}</a> or <a href="command:git.clone">${escape(localize('welcomePage.gitClone', "clone repository..."))}</a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
This PR fixes the "Open Folder" link on the Welcome page. 

## Changes
- update Welcome Page to use `openFolder`

## Screenshots

https://user-images.githubusercontent.com/3806031/119185923-41312800-ba2c-11eb-8b70-7fd193ebe0a7.mov


## Checklist
- [x] tested locally
- [x] updated `CHANGELOG.md`

Fixes #2921 

Related:
- #3427
- #3436 

