### PR TITLE
fix(ci): update brew-bump.sh to update remote first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ VS Code v1.56.1
 
 ### Development
 
-- fix(ci): update brew-bump.sh to update remote first #0000 @jsjoeio
+- fix(ci): update brew-bump.sh to update remote first #3438 @jsjoeio
 
 ## 3.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,18 @@
 - [Changelog](#changelog)
   - [Next Version](#next-version)
     - [New Features](#new-features)
-  - [3.10.1](#3101)
     - [Bug Fixes](#bug-fixes)
     - [Documentation](#documentation)
     - [Development](#development)
-  - [3.10.0](#3100)
-    - [New Features](#new-features-1)
+  - [3.10.1](#3101)
     - [Bug Fixes](#bug-fixes-1)
     - [Documentation](#documentation-1)
     - [Development](#development-1)
+  - [3.10.0](#3100)
+    - [New Features](#new-features-1)
+    - [Bug Fixes](#bug-fixes-2)
+    - [Documentation](#documentation-2)
+    - [Development](#development-2)
   - [Previous versions](#previous-versions)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -59,8 +62,20 @@ VS Code v1.56.1
 
 ### New Features
 
-- feat: support `extraInitContainers` in helm chart values
-- feat: change `extraContainers` to support templating in helm chart
+- feat: support `extraInitContainers` in helm chart values #3393 @strowk
+- feat: change `extraContainers` to support templating in helm chart #3393 @strowk
+
+### Bug Fixes
+
+- fix: use correct command to Open Folder on Welcome page #3437 @jsjoeio
+
+### Documentation
+
+- item
+
+### Development
+
+- fix(ci): update brew-bump.sh to update remote first #0000 @jsjoeio
 
 ## 3.10.1
 
@@ -71,7 +86,6 @@ VS Code v1.56.1
 - fix: Check the logged user instead of $USER #3330 @videlanicolas
 - fix: Fix broken node_modules.asar symlink in npm package #3355 @code-asher
 - fix: Update cloud agent to fix version issue #3342 @oxy
-- fix: use correct command to Open Folder on Welcome page #3437 @jsjoeio
 
 ### Documentation
 
@@ -80,7 +94,6 @@ VS Code v1.56.1
 - docs(maintaining): add merge strategies section #3379 @jsjoeio
 - refactor: move default PR template #3375 @jsjoeio
 - docs(contributing): add commits section #3377 @jsjoeio
-- docs(maintaining): add process for release managers #3360 @jsjoeio
 
 ### Development
 

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -5,9 +5,36 @@ main() {
   cd "$(dirname "$0")/../.."
   # Only sourcing this so we get access to $VERSION
   source ./ci/lib.sh
+
+  # NOTE: we need to make sure cdrci/homebrew-core
+  # is up-to-date
+  # otherwise, brew bump-formula-pr will use an
+  # outdated base
+  echo "Cloning cdrci/homebrew-core"
+  git clone https://github.com/cdrci/homebrew-core.git
+
+  echo "Changing into homebrew-core directory"
+  cd homebrew-core && pwd
+
+  echo "Adding Homebrew/homebrew-core as $(upstream)"
+  git remote add upstream https://github.com/Homebrew/homebrew-core.git
+
+  echo "Fetching upstream commits..."
+  git fetch upstream
+
+  echo "Merging in latest changes"
+  git merge upstream/master
+
+  echo "Pushing changes to cdrci/homebrew-core fork on GitHub"
+  git push origin master
+
   # Find the docs for bump-formula-pr here
   # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18
   brew bump-formula-pr --force --version="${VERSION}" code-server --no-browse --no-audit
+
+  # Clean up and remove homebrew-core
+  cd ..
+  rm -rf homebrew-core
 }
 
 main "$@"


### PR DESCRIPTION
This PR updates `brew-bump.sh` to ensure `cdrci/homebrew-core` is up-to-date before bumping the formula in the publish workflow.

## Changes
- update `brew-bump.sh` script

## Screenshots
todo

## Checklist
- [x] updated `CHANGELOG.md`

Fixes #3407 

