### PR TITLE
fix: remove CHANGELOG from fmt.sh and remove toc from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-# Changelog
-
-- [Changelog](#changelog)
-- [Next Version](#next-version)
-    - [Documentation](#documentation)
-  - [3.10.2](#3102)
-    - [New Features](#new-features)
-    - [Bug Fixes](#bug-fixes)
-    - [Development](#development)
-  - [3.10.1](#3101)
-    - [Bug Fixes](#bug-fixes-1)
-    - [Documentation](#documentation-1)
-    - [Development](#development-1)
-  - [3.10.0](#3100)
-    - [New Features](#new-features-1)
-    - [Bug Fixes](#bug-fixes-2)
-    - [Documentation](#documentation-2)
-    - [Development](#development-2)
-  - [Previous versions](#previous-versions)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Changelog
 
 <!--
@@ -57,13 +33,14 @@ VS Code v0.00.0
 
 -->
 
-# Next Version
+## Next Version
 
 VS Code v0.00.0
 
 ### Documentation
 
 - docs: fix confusing sentence in pull requests section #3460 @shiv-tyagi
+- docs: remove toc from changelog @oxy @jsjoeio
 
 ## 3.10.2
 

--- a/ci/dev/fmt.sh
+++ b/ci/dev/fmt.sh
@@ -31,7 +31,6 @@ main() {
   doctoc --title '# Contributor Covenant Code of Conduct' docs/CODE_OF_CONDUCT.md >/dev/null
   doctoc --title '# iPad' docs/ipad.md >/dev/null
   doctoc --title '# Termux' docs/termux.md >/dev/null
-  doctoc --title '# Changelog' CHANGELOG.md >/dev/null
 
   if [[ ${CI-} && $(git ls-files --other --modified --exclude-standard) ]]; then
     echo "Files need generation or are formatted incorrectly:"


### PR DESCRIPTION
This PR removes `CHANGELOG` from `fmt.sh` and removes the table of contents from `CHANGELOG`. 

Why?

It causes more headache than value. We don't need a table of contents in the `CHANGELOG` and we shouldn't make contributors run `yarn fmt` after updating the `CHANGELOG`.

## Checklist

- [ ] updated `CHANGELOG.md`
