### PR TITLE
docs(MAINTAINING): add information about CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,21 +3,24 @@
 # Changelog
 
 - [Changelog](#changelog)
-- [Next Version](#next-version)
-    - [Documentation](#documentation)
-  - [3.10.2](#3102)
+  - [Next Version](#next-version)
     - [New Features](#new-features)
     - [Bug Fixes](#bug-fixes)
+    - [Documentation](#documentation)
     - [Development](#development)
-  - [3.10.1](#3101)
-    - [Bug Fixes](#bug-fixes-1)
-    - [Documentation](#documentation-1)
-    - [Development](#development-1)
-  - [3.10.0](#3100)
+  - [3.10.2](#3102)
     - [New Features](#new-features-1)
+    - [Bug Fixes](#bug-fixes-1)
+    - [Development](#development-1)
+  - [3.10.1](#3101)
     - [Bug Fixes](#bug-fixes-2)
-    - [Documentation](#documentation-2)
+    - [Documentation](#documentation-1)
     - [Development](#development-2)
+  - [3.10.0](#3100)
+    - [New Features](#new-features-2)
+    - [Bug Fixes](#bug-fixes-3)
+    - [Documentation](#documentation-2)
+    - [Development](#development-3)
   - [Previous versions](#previous-versions)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -57,13 +60,26 @@ VS Code v0.00.0
 
 -->
 
-# Next Version
+## Next Version
 
 VS Code v0.00.0
+
+### New Features
+
+- item
+
+### Bug Fixes
+
+- item
 
 ### Documentation
 
 - docs: fix confusing sentence in pull requests section #3460 @shiv-tyagi
+- docs(MAINTAINING): add information about CHANGELOG #3467 @jsjoeio
+
+### Development
+
+- item
 
 ## 3.10.2
 

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -10,6 +10,7 @@
   - [Versioning](#versioning)
   - [Pull Requests](#pull-requests)
     - [Merge Strategies](#merge-strategies)
+    - [Changelog](#changelog)
   - [Release](#release)
     - [Release Manager Rotation](#release-manager-rotation)
 
@@ -78,6 +79,14 @@ If a PR does fix an issue, don't add it to the version milestone. Otherwise, the
 
 For most things, we recommend "Squash and Merge". If you're updating `lib/vscode`, we suggest using the "Rebase and Merge" strategy. There may be times where "Create a merge commit" makes sense as well. Use your best judgement. If you're unsure, you can always discuss in the PR with the team.
 The code-server project follows traditional [semantic versioning](ttps://semver.org/), with the objective of minimizing major changes that break backward compatibility. We increment the patch level for all releases, except when the upstream Visual Studio Code project increments its minor version or we change the plugin API in a backward-compatible manner. In those cases, we increment the minor version rather than the patch level.
+
+### Changelog
+
+To save time when creating a new release for code-server, we keep a running changelog at `CHANGELOG.md`.
+
+If either author or reviewer of a PR believe the change should be mentioned in the `CHANGELOG`, then it should be added.
+
+If there is not a "Next Version" when you modify `CHANGELOG`, please add it using the template you see near the top of `CHANGELOG`. You can use the suggested format: `<pr title> <pr #> <author> Example: `fix: Check the logged user instead of $USER #3330 @videlanicolas`
 
 ## Release
 


### PR DESCRIPTION
This PR adds docs around `CHANGELOG`. 

Fixes #3412 

## Checklist

- [x] updated `CHANGELOG.md`
