### PR TITLE
fix(publish): update cdrci fork in brew-bump.sh

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,6 +42,13 @@ jobs:
     needs: npm
     runs-on: macos-latest
     steps:
+      # Ensure things are up to date
+      # Suggested by homebrew maintainers
+      # https://github.com/Homebrew/discussions/discussions/1532#discussioncomment-782633
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
       - uses: actions/checkout@v2
       - name: Configure git
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ VS Code v0.00.0
 - chore: cross-compile docker images with buildx #3166 @oxy
 - chore: update node to v14 #3458 @oxy
 
+### Development
+
+- fix(publish): update cdrci fork in brew-bump.sh #3468 @jsjoeio
+
 ## 3.10.2
 
 VS Code v1.56.1

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -29,7 +29,11 @@ main() {
   # Source: https://serverfault.com/a/912788
   # shellcheck disable=SC2016,SC2028
   echo '#!/bin/sh\nexec echo "$HOMEBREW_GITHUB_API_TOKEN"' >"$HOME"/.git-askpass.sh
-  GIT_ASKPASS="$HOME/.git-askpass.sh" git push https://cdrci@github.com/cdrci/homebrew-core.git --all
+  # Ensure it's executable since we just created it
+  chmod +x "$HOME/.git-askpass.sh"
+  # GIT_ASKPASS lets us use the password when pushing without revealing it in the process list
+  # See: https://serverfault.com/a/912788
+  GIT_ASKPASS="$HOME/.git-askpass.sh" git push https://cdr-oss@github.com/cdr-oss/homebrew-core.git --all
 
   # Find the docs for bump-formula-pr here
   # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18

--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -26,7 +26,10 @@ main() {
   git merge upstream/master
 
   echo "Pushing changes to cdrci/homebrew-core fork on GitHub"
-  git push origin master
+  # Source: https://serverfault.com/a/912788
+  # shellcheck disable=SC2016,SC2028
+  echo '#!/bin/sh\nexec echo "$HOMEBREW_GITHUB_API_TOKEN"' >"$HOME"/.git-askpass.sh
+  GIT_ASKPASS="$HOME/.git-askpass.sh" git push https://cdrci@github.com/cdrci/homebrew-core.git --all
 
   # Find the docs for bump-formula-pr here
   # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18


### PR DESCRIPTION
This PR fixes the homebrew `brew-bump.sh` step which runs when we publish a new release.

## Additional Context

### Problem

When we publish a new release, we run a script to bump the formula for code-server on homebrew. The script works using `cdrci`'s GitHub token (secret in repo) so that the PR comes from them and not a maintainer.

The problem is `bump-formula-pr` uses the user's `homebrew-core` fork.

This means we need to ensure the fork is up-to-date.

To do that, we need to pull the remote and push the changes to the fork before running `bump-formula-pr`.

We tried to see if it would "just work" by pulling and pushing, but the push command asks for a username and password.

### Solution

You can get around this with `--all`. We found this solution [here](https://serverfault.com/a/912788).

> This has the advantage that the password won't be visible in the process list too.

## Changes
- update `brew-bump.sh`

## Screenshots

Tested locally and this new approach should work. 
![image](https://user-images.githubusercontent.com/3806031/119553076-1eff1900-bd50-11eb-900b-f190f72a24c6.png)


## Checklist
- [x] add to repo secrets
- [x] tested locally
- [x] updated `CHANGELOG.md`

Fixes #3444 