### PR TITLE
feat(ci): add restore-keys for ci speedup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
         with:
           path: "**/node_modules"
           key: yarn-build-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-build-
 
       - name: Install dependencies
         if: steps.cache-yarn.outputs.cache-hit != 'true'
@@ -78,6 +80,8 @@ jobs:
         with:
           path: "**/node_modules"
           key: yarn-build-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-build-
 
       - name: Install dependencies
         if: steps.cache-yarn.outputs.cache-hit != 'true'
@@ -107,6 +111,8 @@ jobs:
         with:
           path: "**/node_modules"
           key: yarn-build-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-build-
 
       - name: Install dependencies
         if: steps.cache-yarn.outputs.cache-hit != 'true'
@@ -347,6 +353,8 @@ jobs:
         with:
           path: "**/node_modules"
           key: yarn-build-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            yarn-build-
 
       - name: Download release packages
         uses: actions/download-artifact@v2

--- a/ci/build/npm-postinstall.sh
+++ b/ci/build/npm-postinstall.sh
@@ -75,7 +75,7 @@ main() {
 
 # This is a copy of symlink_asar in ../lib.sh. Look there for details.
 symlink_asar() {
-  rm -f node_modules.asar
+  rm -rf node_modules.asar
   if [ "${WINDIR-}" ]; then
     mklink /J node_modules.asar node_modules
   else

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -113,7 +113,7 @@ RELEASE_PATH="${RELEASE_PATH-release}"
 # Code itself but also extensions will look specifically in this directory for
 # files (like the ripgrep binary or the oniguruma wasm).
 symlink_asar() {
-  rm -f node_modules.asar
+  rm -rf node_modules.asar
   if [ "${WINDIR-}" ]; then
     # mklink takes the link name first.
     mklink /J node_modules.asar node_modules


### PR DESCRIPTION
See https://github.com/actions/cache/blob/main/examples.md#node---yarn for an example. `restore-keys` will pull from an older set of dependencies in the cache, then update them and store them again, instead of starting from scratch.

This should bring us decent speed benefits for Dependabot PRs that update a few packages at a time.

## Checklist

- [ ] updated `CHANGELOG.md`
