### PR TITLE
Catch getLayoutMap error

### DIFF
--- a/lib/vscode/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
+++ b/lib/vscode/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
@@ -406,6 +406,9 @@ export class BrowserKeyboardMapperFactoryBase {
 					// }
 
 					// return null;
+				}).catch(() => {
+					// NOTE@coder: It looks like the intention was to catch this error but
+					// a try/catch won't do it when using promises without `await`.
 				});
 			} catch {
 				// getLayoutMap can throw if invoked from a nested browsing context


### PR DESCRIPTION
This might be causing issues with the PWA showing a blank screen with
MacOS.

I've opted not to add a changelog item yet because it's untested whether this fixes the issue.