### PR TITLE
Allow code-server to identify raspberry pi 4 (armv7l)

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -35,7 +35,8 @@ os() {
 }
 
 arch() {
-  case "$(uname -m)" in
+  cpu="$(uname -m)"
+  case "$cpu" in
   aarch64)
     echo arm64
     ;;
@@ -43,8 +44,7 @@ arch() {
     echo amd64
     ;;
   *)
-    echo "unknown architecture $(uname -a)"
-    exit 1
+    echo "$cpu"
     ;;
   esac
 }


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->
This is a one line fix, so adding a PR seems a lot (but will do if demanded).

This fix is only interesting for developers trying to use raspberry pi 4.

With this patch `yarn` passes. The general plan is to work through all issues in being able to build the code on a raspberry pi 4.

Next PR will concentrate on `yarn watch`.

Edit: 
Arch() will not either return the converted cpu type or raw “uname -m”
Fixes #3612
## Checklist

- [ ] updated `CHANGELOG.md`
