### PR TITLE
fix: placeholder password in hashed password example

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -206,7 +206,7 @@ Again, please follow [./guide.md](./guide.md) for our recommendations on setting
 Yes you can! Set the value of `hashed-password` instead of `password`. Generate the hash with:
 
 ```shell
-echo -n "password" | npx argon2-cli -e
+echo -n "thisismypassword" | npx argon2-cli -e
 $argon2i$v=19$m=4096,t=3,p=1$wst5qhbgk2lu1ih4dmuxvg$ls1alrvdiwtvzhwnzcm1dugg+5dto3dt1d5v9xtlws4
 ```
 


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->
This PR fixes a minor mistake with the new hashed password section in docs, changes made to align the example with the correct placeholder text.

## Checklist

- [ ] updated `CHANGELOG.md`
