### PR TITLE
docs: Update CONTRIBUTING.md

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -35,7 +35,7 @@ The prerequisites for contributing to code-server are almost the same as those f
 [VS Code](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#prerequisites).
 There are several differences, however. Here is what is needed:
 
-- `node` v14.x or greater
+- `node` v14.x
 - `git` v2.x or greater
 - [`yarn`](https://classic.yarnpkg.com/en/)
   - used to install JS packages and run scripts


### PR DESCRIPTION
Node needs be v14.x not greater. If installing the standard version ‘brew install node’, both ‘yarn’ and ‘code-server’ (release version) complains.

Newest version is v16.x so we are pretty far behind.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

## Checklist

- [ ] updated `CHANGELOG.md`
