### PR TITLE
docs: move README to docs

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -22,7 +22,7 @@ main() {
   bundle_code_server
   bundle_vscode
 
-  rsync README.md "$RELEASE_PATH"
+  rsync ./docs/README.md "$RELEASE_PATH"
   rsync LICENSE.txt "$RELEASE_PATH"
   rsync ./lib/vscode/ThirdPartyNotices.txt "$RELEASE_PATH"
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,6 @@
 # code-server &middot;
 
-<div class="badges">
-  [!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions)
-  [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community)
-  [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
-  [![codecov](https://codecov.io/gh/cdr/code-server/branch/main/graph/badge.svg?token=5iM9farjnC)](https://codecov.io/gh/cdr/code-server)
-  [![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.10.2/docs)
-</div>
+[!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq) [![codecov](https://codecov.io/gh/cdr/code-server/branch/main/graph/badge.svg?token=5iM9farjnC)](https://codecov.io/gh/cdr/code-server) [![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.10.2/docs)
 
 Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and access it in the browser.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# code-server &middot;
+# code-server
 
 [!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq) [![codecov](https://codecov.io/gh/cdr/code-server/branch/main/graph/badge.svg?token=5iM9farjnC)](https://codecov.io/gh/cdr/code-server) [![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.10.2/docs)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,12 @@
-# code-server &middot; [!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
+# code-server &middot;
 
-[![codecov](https://codecov.io/gh/cdr/code-server/branch/main/graph/badge.svg?token=5iM9farjnC)](https://codecov.io/gh/cdr/code-server)
-[![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.10.2/docs)
+<div class="badges">
+  [!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions)
+  [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community)
+  [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq)
+  [![codecov](https://codecov.io/gh/cdr/code-server/branch/main/graph/badge.svg?token=5iM9farjnC)](https://codecov.io/gh/cdr/code-server)
+  [![See latest docs](https://img.shields.io/static/v1?label=Docs&message=see%20latest%20&color=blue)](https://github.com/cdr/code-server/tree/v3.10.2/docs)
+</div>
 
 Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and access it in the browser.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 
 Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and access it in the browser.
 
-![Screenshot](./docs/assets/screenshot.png)
+![Screenshot](./assets/screenshot.png)
 
 ## Highlights
 
@@ -20,14 +20,14 @@ For a good experience, we recommend at least:
 - 1 GB of RAM
 - 2 cores
 
-You can use whatever linux distribution floats your boat but in our [guide](./docs/guide.md) we assume Debian on Google Cloud.
+You can use whatever linux distribution floats your boat but in our [guide](./guide.md) we assume Debian on Google Cloud.
 
 ## Getting Started
 
 There are three ways you can get started:
 
-1. Using the [install script](./install.sh), which automates most of the process. The script uses the system package manager (if possible)
-2. Manually installing code-server; see [Installation](./docs/install.md) for instructions applicable to most use cases
+1. Using the [install script](https://github.com/cdr/code-server/blob/main/install.sh), which automates most of the process. The script uses the system package manager (if possible)
+2. Manually installing code-server; see [Installation](./install.md) for instructions applicable to most use cases
 3. Use our one-click buttons and guides to [deploy code-server to a popular cloud provider](https://github.com/cdr/deploy-code-server) ⚡
 
 If you choose to use the install script, you can preview what occurs during the install process:
@@ -44,7 +44,7 @@ curl -fsSL https://code-server.dev/install.sh | sh
 
 When done, the install script prints out instructions for running and starting code-server.
 
-We also have an in-depth [setup and configuration](./docs/guide.md) guide.
+We also have an in-depth [setup and configuration](./guide.md) guide.
 
 ### code-server --link
 
@@ -62,11 +62,11 @@ Proxying code-server, you can access your IDE at https://valmar-jon.cdr.co
 
 ## FAQ
 
-See [./docs/FAQ.md](./docs/FAQ.md).
+See [./FAQ.md](./FAQ.md).
 
 ## Want to help?
 
-See [CONTRIBUTING](./docs/CONTRIBUTING.md) for details.
+See [CONTRIBUTING](./CONTRIBUTING.md) for details.
 
 ## Hiring
 


### PR DESCRIPTION
As mentioned in https://github.com/cdr/code-server/pull/3582 we decided to move the README into /docs folder. 

Change on code-server docs:
<img width="1680" alt="Screen Shot 2021-06-24 at 14 07 00" src="https://user-images.githubusercontent.com/3165839/123304720-a7124300-d4f5-11eb-8bfd-226eb548033a.png">

On GitHub:
<img width="945" alt="Screen Shot 2021-06-24 at 14 10 14" src="https://user-images.githubusercontent.com/3165839/123304971-f2c4ec80-d4f5-11eb-8387-dd215124c291.png">

