### PR TITLE
Fix broken link on docs site

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -217,7 +217,7 @@ Our official image supports `amd64` and `arm64`.
 
 For `arm32` support there is a popular community maintained alternative:
 
-https://hub.docker.com/r/linuxserver/code-server
+[https://hub.docker.com/r/linuxserver/code-server](https://hub.docker.com/r/linuxserver/code-server)
 
 ## helm
 
@@ -227,4 +227,4 @@ See [the chart](../ci/helm-chart).
 
 We maintain one-click apps and install scripts for different cloud providers such as DigitalOcean, Railway, Heroku, Azure, etc. Check out the repository:
 
-https://github.com/cdr/deploy-code-server
+[https://github.com/cdr/deploy-code-server](https://github.com/cdr/deploy-code-server)


### PR DESCRIPTION
Links don't work on docs site unless they have md formatting. Fix is minor.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

