### PR TITLE
fix: escape error.message on login failure

### DIFF
--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -7,7 +7,7 @@ import { normalize, Options } from "../common/util"
 import { AuthType, DefaultedArgs } from "./cli"
 import { commit, rootPath } from "./constants"
 import { Heart } from "./heart"
-import { getPasswordMethod, IsCookieValidArgs, isCookieValid, sanitizeString } from "./util"
+import { getPasswordMethod, IsCookieValidArgs, isCookieValid, sanitizeString, escapeHtml } from "./util"
 
 declare global {
   // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -35,7 +35,7 @@ export const replaceTemplates = <T extends object>(
     ...extraOpts,
   }
   return content
-    .replace(/{{TO}}/g, (typeof req.query.to === "string" && req.query.to) || "/")
+    .replace(/{{TO}}/g, (typeof req.query.to === "string" && escapeHtml(req.query.to)) || "/")
     .replace(/{{BASE}}/g, options.base)
     .replace(/{{CS_STATIC_BASE}}/g, options.csStaticBase)
     .replace(/"{{OPTIONS}}"/, `'${JSON.stringify(options)}'`)

--- a/src/node/http.ts
+++ b/src/node/http.ts
@@ -100,7 +100,8 @@ export const relativeRoot = (req: express.Request): string => {
 }
 
 /**
- * Redirect relatively to `/${to}`. Query variables will be preserved.
+ * Redirect relatively to `/${to}`. Query variables on the current URI will be preserved.
+ * `to` should be a simple path without any query parameters
  * `override` will merge with the existing query (use `undefined` to unset).
  */
 export const redirect = (

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -112,7 +112,7 @@ router.post("/", async (req, res) => {
 
     throw new Error("Incorrect password")
   } catch (error) {
-    const htmlToRender = await getRoot(req, error)
-    res.send(htmlToRender)
+    const renderedHtml = await getRoot(req, error)
+    res.send(renderedHtml)
   }
 })

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -41,7 +41,7 @@ const getRoot = async (req: Request, error?: Error): Promise<string> => {
     req,
     content
       .replace(/{{PASSWORD_MSG}}/g, passwordMsg)
-      .replace(/{{ERROR}}/, error ? `<div class="error">${error.message}</div>` : ""),
+      .replace(/{{ERROR}}/, error ? `<div class="error">${escapeHtml(error.message)}</div>` : ""),
   )
 }
 
@@ -112,8 +112,7 @@ router.post("/", async (req, res) => {
 
     throw new Error("Incorrect password")
   } catch (error) {
-    const html = await getRoot(req, error)
-    const escapedHtml = escapeHtml(html)
-    res.send(escapedHtml)
+    const htmlToRender = await getRoot(req, error)
+    res.send(htmlToRender)
   }
 })

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -4,7 +4,7 @@ import { RateLimiter as Limiter } from "limiter"
 import * as path from "path"
 import { rootPath } from "../constants"
 import { authenticated, getCookieDomain, redirect, replaceTemplates } from "../http"
-import { getPasswordMethod, handlePasswordValidation, humanPath, sanitizeString } from "../util"
+import { getPasswordMethod, handlePasswordValidation, humanPath, sanitizeString, escapeHtml } from "../util"
 
 export enum Cookie {
   Key = "key",
@@ -36,6 +36,7 @@ const getRoot = async (req: Request, error?: Error): Promise<string> => {
   } else if (req.args.usingEnvHashedPassword) {
     passwordMsg = "Password was set from $HASHED_PASSWORD."
   }
+
   return replaceTemplates(
     req,
     content
@@ -111,6 +112,8 @@ router.post("/", async (req, res) => {
 
     throw new Error("Incorrect password")
   } catch (error) {
-    res.send(await getRoot(req, error))
+    const html = await getRoot(req, error)
+    const escapedHtml = escapeHtml(html)
+    res.send(escapedHtml)
   }
 })

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -520,5 +520,5 @@ export function escapeHtml(unsafe: string): string {
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;")
     .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;")
+    .replace(/'/g, "&apos;")
 }

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -508,3 +508,17 @@ export const isFile = async (path: string): Promise<boolean> => {
     return false
   }
 }
+
+/**
+ * Escapes any HTML string special characters, like &, <, >, ", and '.
+ *
+ * Source: https://stackoverflow.com/a/6234804/3015595
+ **/
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;")
+}

--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -448,8 +448,8 @@ describe("onLine", () => {
 
 describe("escapeHtml", () => {
   it("should escape HTML", () => {
-    expect(util.escapeHtml(`<div class="error">"Hello & world"</div>`)).toBe(
-      "&lt;div class=&quot;error&quot;&gt;&quot;Hello &amp; world&quot;&lt;/div&gt;",
+    expect(util.escapeHtml(`<div class="error">"'ello & world"</div>`)).toBe(
+      "&lt;div class=&quot;error&quot;&gt;&quot;&apos;ello &amp; world&quot;&lt;/div&gt;",
     )
   })
 })

--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -445,3 +445,11 @@ describe("onLine", () => {
     expect(await received).toEqual(expected)
   })
 })
+
+describe("escapeHtml", () => {
+  it("should escape HTML", () => {
+    expect(util.escapeHtml(`<div class="error">"Hello & world"</div>`)).toBe(
+      "&lt;div class=&quot;error&quot;&gt;&quot;Hello &amp; world&quot;&lt;/div&gt;",
+    )
+  })
+})

--- a/test/unit/routes/login.test.ts
+++ b/test/unit/routes/login.test.ts
@@ -1,7 +1,6 @@
+import { RateLimiter } from "../../../src/node/routes/login"
 import * as httpserver from "../../utils/httpserver"
 import * as integration from "../../utils/integration"
-
-import { RateLimiter } from "../../../src/node/routes/login"
 
 describe("login", () => {
   describe("RateLimiter", () => {
@@ -56,8 +55,12 @@ describe("login", () => {
       _codeServer = await integration.setup(["--auth=password"], "")
     })
 
-    afterEach(() => {
+    afterEach(async () => {
       process.env.PASSWORD = previousEnvPassword
+      if (_codeServer) {
+        await _codeServer.close()
+        _codeServer = undefined
+      }
     })
 
     it("should return HTML with 'Missing password' message", async () => {

--- a/test/unit/routes/login.test.ts
+++ b/test/unit/routes/login.test.ts
@@ -1,3 +1,6 @@
+import * as httpserver from "../../utils/httpserver"
+import * as integration from "../../utils/integration"
+
 import { RateLimiter } from "../../../src/node/routes/login"
 
 describe("login", () => {
@@ -32,6 +35,43 @@ describe("login", () => {
 
       expect(limiter.canTry()).toBe(false)
       expect(limiter.removeToken()).toBe(false)
+    })
+  })
+  describe("/login", () => {
+    let _codeServer: httpserver.HttpServer | undefined
+    function codeServer(): httpserver.HttpServer {
+      if (!_codeServer) {
+        throw new Error("tried to use code-server before setting it up")
+      }
+      return _codeServer
+    }
+
+    // Store whatever might be in here so we can restore it afterward.
+    // TODO: We should probably pass this as an argument somehow instead of
+    // manipulating the environment.
+    const previousEnvPassword = process.env.PASSWORD
+
+    beforeEach(async () => {
+      process.env.PASSWORD = "test"
+      _codeServer = await integration.setup(["--auth=password"], "")
+    })
+
+    afterEach(() => {
+      process.env.PASSWORD = previousEnvPassword
+    })
+
+    it("should return escaped HTML with 'Missing password' message", async () => {
+      const resp = await codeServer().fetch("/login", { method: "POST" })
+
+      expect(resp.status).toBe(200)
+
+      const htmlContent = await resp.text()
+
+      expect(htmlContent).not.toContain(">")
+      expect(htmlContent).not.toContain("<")
+      expect(htmlContent).not.toContain('"')
+      expect(htmlContent).not.toContain("'")
+      expect(htmlContent).toContain("&lt;div class=&quot;error&quot;&gt;Missing password&lt;/div&gt;")
     })
   })
 })

--- a/test/unit/routes/login.test.ts
+++ b/test/unit/routes/login.test.ts
@@ -60,18 +60,14 @@ describe("login", () => {
       process.env.PASSWORD = previousEnvPassword
     })
 
-    it("should return escaped HTML with 'Missing password' message", async () => {
+    it("should return HTML with 'Missing password' message", async () => {
       const resp = await codeServer().fetch("/login", { method: "POST" })
 
       expect(resp.status).toBe(200)
 
       const htmlContent = await resp.text()
 
-      expect(htmlContent).not.toContain(">")
-      expect(htmlContent).not.toContain("<")
-      expect(htmlContent).not.toContain('"')
-      expect(htmlContent).not.toContain("'")
-      expect(htmlContent).toContain("&lt;div class=&quot;error&quot;&gt;Missing password&lt;/div&gt;")
+      expect(htmlContent).toContain("Missing password")
     })
   })
 })


### PR DESCRIPTION
This PR fixes a security issue by sanitizing the `error.message` before sending it back to the client on a login failure.

## Changes
- add function `escapeHtml` + tests
- fix: escape `error.message` before sending to client on login failure

## Checklist
- [x] tested locally
- [x] added a test

Fixes #3382
