### PR TITLE
docs(guide): add WebSockets to requirements

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -45,6 +45,8 @@ For a good experience, we recommend at least:
 
 You can use whatever linux distribution floats your boat but in this guide we assume Debian on Google Cloud.
 
+In order to work properly, your environment should have WebSockets enabled, which code-server uses to communicate between the browser and server
+
 ### Google Cloud
 
 For demonstration purposes, this guide assumes you're using a VM on GCP but you should be


### PR DESCRIPTION
This PR updates the requirements in `guide.md` by adding a line about WebSockets.

We've had people in the past not enable WebSockets in their environment, leading to code-server not working.

Evidence
- https://github.com/cdr/code-server/discussions/3667#discussioncomment-934888
- https://github.com/cdr/code-server/discussions/3175#discussioncomment-640924