### PR TITLE
fix(isHashMatch): check that hash starts with $

### DIFF
--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -166,14 +166,13 @@ export const hash = async (password: string): Promise<string> => {
  * Used to verify if the password matches the hash
  */
 export const isHashMatch = async (password: string, hash: string) => {
-  if (password === "" || hash === "") {
+  if (password === "" || hash === "" || !hash.startsWith("$")) {
     return false
   }
   try {
     return await argon2.verify(hash, password)
   } catch (error) {
-    logger.error(error)
-    return false
+    throw new Error(error)
   }
 }
 

--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -189,6 +189,17 @@ describe("isHashMatch", () => {
     const actual = await util.isHashMatch(password, _hash)
     expect(actual).toBe(false)
   })
+  it("should return false and not throw an error if the hash doesn't start with a $", async () => {
+    const password = "hellowpasssword"
+    const _hash = "n2i$v=19$m=4096,t=3,p=1$EAoczTxVki21JDfIZpTUxg$rkXgyrW4RDGoDYrxBFD4H2DlSMEhP4h+Api1hXnGnFY"
+    expect(async () => await util.isHashMatch(password, _hash)).not.toThrow()
+    expect(await util.isHashMatch(password, _hash)).toBe(false)
+  })
+  it("should reject the promise and throw if error", async () => {
+    const password = "hellowpasssword"
+    const _hash = "$ar2i"
+    expect(async () => await util.isHashMatch(password, _hash)).rejects.toThrow()
+  })
 })
 
 describe("hashLegacy", () => {


### PR DESCRIPTION
This PR adds an additional check to `isHashMatch` to check that the hash starts with a "$" to prevent us from calling `argon2.verify` if it doesn't.

It also throws an error if something goes wrong with the `.verify()` function.

**Why do we need to add this?**

The other day I noticed this error: `'TypeError: pchstr must contain a $ as first char\n'`

I believe it happens because we're still in between a migration from the old hashing function `sha256` to the new one `argon2`. And locally, I switch between the latest code-server and the development one. This means it may be calling the function to verify the hash expecting it to be a hash made with `argon2` and instead it's made with `sha256`. 

Once we release the newest version of code-server with the `argon2` algorithm, we don't want it to throw unexpected errors, like this one. We may need to revisit some of the logic for verifying password hashes in case there are issues.

Either way, this adds an extra check to prevent this error from happening.

Fixes N/A
