### PR TITLE
feat(test): try calling .dispose() x2 in emitter

### DIFF
--- a/test/unit/emitter.test.ts
+++ b/test/unit/emitter.test.ts
@@ -41,7 +41,7 @@ describe("emitter", () => {
 
     // Register the onHelloWorld listener
     // and the onGoodbyeWorld
-    emitter.event(onHelloWorld)
+    const _onHelloWorld = emitter.event(onHelloWorld)
     emitter.event(onGoodbyeWorld)
 
     await emitter.emit({ event: HELLO_WORLD, callback: mockCallback })
@@ -55,6 +55,12 @@ describe("emitter", () => {
     // Check that it works with multiple listeners
     expect(mockSecondCallback).toHaveBeenCalled()
     expect(mockSecondCallback).toHaveBeenCalledTimes(1)
+
+    // Dispose of individual listener
+    _onHelloWorld.dispose()
+
+    // Try disposing twice
+    _onHelloWorld.dispose()
 
     // Dispose of all the listeners
     emitter.dispose()


### PR DESCRIPTION
This adds a couple lines to hit 100% test coverage for `emitter.ts` by ensuring that our logic works when trying to `dispose` of a callback more than once. 

![image](https://user-images.githubusercontent.com/3806031/124330289-ef5ae200-db41-11eb-84e5-bd67b7cd002a.png)

Fixes N/A
