### PR TITLE
feat(test): check login.ts when base missing

### DIFF
--- a/test/browser/pages/login.test.ts
+++ b/test/browser/pages/login.test.ts
@@ -42,4 +42,49 @@ describe("login", () => {
       expect(el?.value).toBe("/hello-world")
     })
   })
+  describe("there is not an element with id 'base'", () => {
+    let spy: jest.SpyInstance
+
+    beforeAll(() => {
+      // This is important because we're manually requiring the file
+      // If you don't call this before all tests
+      // the module registry from other tests may cause side effects.
+      jest.resetModuleRegistry()
+    })
+
+    beforeEach(() => {
+      const dom = new JSDOM()
+      global.document = dom.window.document
+      spy = jest.spyOn(document, "getElementById")
+
+      const location: LocationLike = {
+        pathname: "/healthz",
+        origin: "http://localhost:8080",
+      }
+
+      global.location = location as Location
+    })
+
+    afterEach(() => {
+      spy.mockClear()
+      jest.resetModules()
+      // Reset the global.document
+      global.document = undefined as any as Document
+      global.location = undefined as any as Location
+    })
+
+    afterAll(() => {
+      jest.restoreAllMocks()
+    })
+
+    it("should do nothing", () => {
+      spy.mockImplementation(() => null)
+      // Load file
+      require("../../../src/browser/pages/login")
+
+      // It's called once by getOptions in the top of the file
+      // and then another to get the base element
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+  })
 })


### PR DESCRIPTION
This PR adds a new test for `login.ts` to check our logic works when it doesn't find an element with the id "base".

![image](https://user-images.githubusercontent.com/3806031/124332261-f1bf3b00-db45-11eb-8bda-61b12a122fc0.png)

Fixes N/A
