### PR TITLE
docs(guide): add note about configuration for NGINX

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -261,6 +261,8 @@ Make sure to substitute `me@example.com` with your actual email.
 
 Visit `https://<your-domain-name>` to access `code-server`. Congratulations!
 
+Note: if you set `proxy_set_header Host $host;` in your reverse proxy config, it will change the address displayed in the green section of code-server in the bottom left to show the correct address.
+
 ### Self Signed Certificate
 
 **note:** Self signed certificates do not work with iPad normally. See [./ipad.md](./ipad.md) for details.


### PR DESCRIPTION
This adds a short note to the NGINX section of `guide.md` for how to configure the green section displayed in code-server's UI.

## Screenshot
![nginx](https://user-images.githubusercontent.com/3806031/124658712-f3944180-de58-11eb-907e-4ebb508c0f11.jpg)

Fixes #3513

(thank you to @sestegra and @nakkaya for pointing this out!)
