### PR TITLE
revert: add eslint-import-resolver-alias as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "doctoc": "^2.0.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^8.1.0",
+    "eslint-import-resolver-alias": "^1.1.2",
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.1.0",
     "prettier": "^2.2.1",


### PR DESCRIPTION
In https://github.com/cdr/code-server/pull/3729, I removed `eslint-import-resolver-alias` because I didn't think we used it but turns out we do to make importing code-server plugins in a test.

I don't fully understand exactly how it works, but it has to with aliasing a module (code-server itself as a module) in one of our tests. I tried putting it in the `test/package.json` but ESLint didn't like that. 
