### PR TITLE
refactor: clean up testing files

### DIFF
--- a/test/unit/browser/pages/login.test.ts
+++ b/test/unit/browser/pages/login.test.ts
@@ -1,5 +1,5 @@
 import { JSDOM } from "jsdom"
-import { LocationLike } from "../../unit/util.test"
+import { LocationLike } from "../../util.test"
 
 describe("login", () => {
   describe("there is an element with id 'base'", () => {
@@ -36,7 +36,7 @@ describe("login", () => {
       document.body.appendChild(mockElement)
       spy.mockImplementation(() => mockElement)
       // Load file
-      require("../../../src/browser/pages/login")
+      require("../../../../src/browser/pages/login")
 
       const el: HTMLInputElement | null = document.querySelector("input#base")
       expect(el?.value).toBe("/hello-world")
@@ -80,7 +80,7 @@ describe("login", () => {
     it("should do nothing", () => {
       spy.mockImplementation(() => null)
       // Load file
-      require("../../../src/browser/pages/login")
+      require("../../../../src/browser/pages/login")
 
       // It's called once by getOptions in the top of the file
       // and then another to get the base element

--- a/test/unit/browser/pages/vscode.test.ts
+++ b/test/unit/browser/pages/vscode.test.ts
@@ -6,7 +6,7 @@ import {
   getNlsConfiguration,
   nlsConfigElementId,
   setBodyBackgroundToThemeBackgroundColor,
-} from "../../../src/browser/pages/vscode"
+} from "../../../../src/browser/pages/vscode"
 
 describe("vscode", () => {
   describe("getNlsConfiguration", () => {

--- a/test/unit/browser/register.test.ts
+++ b/test/unit/browser/register.test.ts
@@ -1,7 +1,7 @@
 import { JSDOM } from "jsdom"
-import { registerServiceWorker } from "../../src/browser/register"
-import { createLoggerMock } from "../utils/helpers"
-import { LocationLike } from "./util.test"
+import { registerServiceWorker } from "../../../src/browser/register"
+import { createLoggerMock } from "../../utils/helpers"
+import { LocationLike } from "../util.test"
 
 describe("register", () => {
   describe("when navigator and serviceWorker are defined", () => {
@@ -50,7 +50,7 @@ describe("register", () => {
 
     it("should register a ServiceWorker", () => {
       // Load service worker like you would in the browser
-      require("../../src/browser/register")
+      require("../../../src/browser/register")
       expect(mockRegisterFn).toHaveBeenCalled()
       expect(mockRegisterFn).toHaveBeenCalledTimes(1)
     })
@@ -64,7 +64,7 @@ describe("register", () => {
       })
 
       // Load service worker like you would in the browser
-      require("../../src/browser/register")
+      require("../../../src/browser/register")
 
       expect(mockRegisterFn).toHaveBeenCalled()
       expect(loggerModule.logger.error).toHaveBeenCalled()
@@ -88,7 +88,7 @@ describe("register", () => {
 
     it("should log an error", () => {
       // Load service worker like you would in the browser
-      require("../../src/browser/register")
+      require("../../../src/browser/register")
       expect(loggerModule.logger.error).toHaveBeenCalled()
       expect(loggerModule.logger.error).toHaveBeenCalledTimes(1)
       expect(loggerModule.logger.error).toHaveBeenCalledWith("[Service Worker] navigator is undefined")

--- a/test/unit/browser/serviceWorker.test.ts
+++ b/test/unit/browser/serviceWorker.test.ts
@@ -58,7 +58,7 @@ describe("serviceWorker", () => {
   })
 
   it("should add 3 listeners: install, activate and fetch", () => {
-    require("../../src/browser/serviceWorker.ts")
+    require("../../../src/browser/serviceWorker.ts")
     const listenerEventNames = listeners.map((listener) => listener.event)
 
     expect(listeners).toHaveLength(3)
@@ -68,20 +68,20 @@ describe("serviceWorker", () => {
   })
 
   it("should call the proper callbacks for 'install'", async () => {
-    require("../../src/browser/serviceWorker.ts")
+    require("../../../src/browser/serviceWorker.ts")
     emit("install")
     expect(spy).toHaveBeenCalledWith("[Service Worker] installed")
     expect(spy).toHaveBeenCalledTimes(1)
   })
 
   it("should do nothing when 'fetch' is called", async () => {
-    require("../../src/browser/serviceWorker.ts")
+    require("../../../src/browser/serviceWorker.ts")
     emit("fetch")
     expect(spy).not.toHaveBeenCalled()
   })
 
   it("should call the proper callbacks for 'activate'", async () => {
-    require("../../src/browser/serviceWorker.ts")
+    require("../../../src/browser/serviceWorker.ts")
     emit("activate")
 
     // Activate serviceWorker

--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -469,9 +469,7 @@ describe("pathToFsPath", () => {
       util
         // @ts-expect-error We need to check other types
         .pathToFsPath({}),
-    ).toThrow(
-      `Could not compute fsPath from given uri. Expected path to be of type string, but was of type undefined.`,
-    )
+    ).toThrow(`Could not compute fsPath from given uri. Expected path to be of type string, but was of type undefined.`)
   })
   it("should not throw an error for a string array", () => {
     // @ts-expect-error We need to check other types


### PR DESCRIPTION
I accidentally merged a PR that didn't have a file formatted correctly and it made CI on `main` fail. This fixes that but also clean ups some testing files to be better organized.
