### PR TITLE
refactor: only accept string in pathToFsPath

### DIFF
--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -63,9 +63,10 @@ router.get("/", async (req, res) => {
  * TODO: Might currently be unused.
  */
 router.get("/resource(/*)?", ensureAuthenticated, async (req, res) => {
-  if (typeof req.query.path === "string") {
-    res.set("Content-Type", getMediaMime(req.query.path))
-    res.send(await fs.readFile(pathToFsPath(req.query.path)))
+  const path = getFirstString(req.query.path)
+  if (path) {
+    res.set("Content-Type", getMediaMime(path))
+    res.send(await fs.readFile(pathToFsPath(path)))
   }
 })
 
@@ -73,9 +74,10 @@ router.get("/resource(/*)?", ensureAuthenticated, async (req, res) => {
  * Used by VS Code to load files.
  */
 router.get("/vscode-remote-resource(/*)?", ensureAuthenticated, async (req, res) => {
-  if (typeof req.query.path === "string") {
-    res.set("Content-Type", getMediaMime(req.query.path))
-    res.send(await fs.readFile(pathToFsPath(req.query.path)))
+  const path = getFirstString(req.query.path)
+  if (path) {
+    res.set("Content-Type", getMediaMime(path))
+    res.send(await fs.readFile(pathToFsPath(path)))
   }
 })
 

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -458,16 +458,10 @@ enum CharCode {
  * Taken from vs/base/common/uri.ts. It's not imported to avoid also importing
  * everything that file imports.
  */
-export function pathToFsPath(path: string | string[], keepDriveLetterCasing = false): string {
+export function pathToFsPath(path: string, keepDriveLetterCasing = false): string {
   const isWindows = process.platform === "win32"
-  const uri = { authority: undefined, path: getFirstString(path), scheme: "file" }
+  const uri = { authority: undefined, path: getFirstString(path) || "", scheme: "file" }
   let value: string
-
-  if (typeof uri.path !== "string") {
-    throw new Error(
-      `Could not compute fsPath from given uri. Expected path to be of type string, but was of type ${typeof uri.path}.`,
-    )
-  }
 
   if (uri.authority && uri.path.length > 1 && uri.scheme === "file") {
     // unc path: file://shares/c$/far/boo

--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -464,19 +464,8 @@ describe("pathToFsPath", () => {
   it("should keep drive letter casing when set to true", () => {
     expect(util.pathToFsPath("/C:/far/bo", true)).toBe("C:/far/bo")
   })
-  it("should throw an error if a non-string is passed in for path", () => {
-    expect(() =>
-      util
-        // @ts-expect-error We need to check other types
-        .pathToFsPath({}),
-    ).toThrow(`Could not compute fsPath from given uri. Expected path to be of type string, but was of type undefined.`)
-  })
-  it("should not throw an error for a string array", () => {
-    // @ts-expect-error We need to check other types
-    expect(() => util.pathToFsPath(["/hello/foo", "/hello/bar"]).not.toThrow())
-  })
   it("should use the first string in a string array", () => {
-    expect(util.pathToFsPath(["/hello/foo", "/hello/bar"])).toBe("/hello/foo")
+    expect(util.pathToFsPath("/hello/foo")).toBe("/hello/foo")
   })
   it("should replace / with \\ on Windows", () => {
     let ORIGINAL_PLATFORM = process.platform

--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -1,6 +1,9 @@
 import * as cp from "child_process"
+import * as path from "path"
+import { promises as fs } from "fs"
 import { generateUuid } from "../../../src/common/util"
 import * as util from "../../../src/node/util"
+import { tmpdir } from "../../../src/node/constants"
 
 describe("getEnvPaths", () => {
   describe("on darwin", () => {
@@ -464,9 +467,6 @@ describe("pathToFsPath", () => {
   it("should keep drive letter casing when set to true", () => {
     expect(util.pathToFsPath("/C:/far/bo", true)).toBe("C:/far/bo")
   })
-  it("should use the first string in a string array", () => {
-    expect(util.pathToFsPath("/hello/foo")).toBe("/hello/foo")
-  })
   it("should replace / with \\ on Windows", () => {
     let ORIGINAL_PLATFORM = process.platform
 
@@ -479,5 +479,25 @@ describe("pathToFsPath", () => {
     Object.defineProperty(process, "platform", {
       value: ORIGINAL_PLATFORM,
     })
+  })
+})
+
+describe("isFile", () => {
+  const testDir = path.join(tmpdir, "tests", "isFile")
+  let pathToFile = ""
+
+  beforeEach(async () => {
+    pathToFile = path.join(testDir, "foo.txt")
+    await fs.mkdir(testDir, { recursive: true })
+    await fs.writeFile(pathToFile, "hello")
+  })
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true })
+  })
+  it("should return false if the path doesn't exist", async () => {
+    expect(await util.isFile(testDir)).toBe(false)
+  })
+  it("should return true if is file", async () => {
+    expect(await util.isFile(pathToFile)).toBe(true)
   })
 })


### PR DESCRIPTION
This PR reverts some work done in https://github.com/cdr/code-server/pull/3751 to make `pathToFsPath` better. 