### PR TITLE
Fix "serviceWorker.js" path

### DIFF
--- a/src/browser/register.ts
+++ b/src/browser/register.ts
@@ -5,7 +5,7 @@ export async function registerServiceWorker(): Promise<void> {
   const options = getOptions()
   logger.level = options.logLevel
 
-  const path = normalize(`${options.csStaticBase}/dist/serviceWorker.js`)
+  const path = normalize(`${options.csStaticBase}/out/browser/serviceWorker.js`)
   try {
     await navigator.serviceWorker.register(path, {
       scope: options.base + "/",

--- a/test/unit/browser/register.test.ts
+++ b/test/unit/browser/register.test.ts
@@ -155,7 +155,7 @@ describe("register", () => {
       await registerServiceWorker()
 
       expect(mockFn).toBeCalled()
-      expect(serviceWorkerPath).toMatch(`${csStaticBasePath}/dist/serviceWorker.js`)
+      expect(serviceWorkerPath).toMatch(`${csStaticBasePath}/out/browser/serviceWorker.js`)
       expect(serviceWorkerScope).toMatch("/")
     })
     it("should register when options.base is defined", async () => {
@@ -176,7 +176,7 @@ describe("register", () => {
       await registerServiceWorker()
 
       expect(mockFn).toBeCalled()
-      expect(serviceWorkerPath).toMatch(`/dist/serviceWorker.js`)
+      expect(serviceWorkerPath).toMatch(`/out/browser/serviceWorker.js`)
       expect(serviceWorkerScope).toMatch("/")
     })
   })


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

3.10.2 had this folder, but it was removed in version 3.11.0
cc @jsjoeio 
