### PR TITLE
chore: update coverage thresholds

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -5,7 +5,7 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: "70...100"
+  range: "40...70"
   patch: off
 
 parsers:

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,6 +6,7 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+  patch: off
 
 parsers:
   gcov:

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     ],
     "coverageThreshold": {
       "global": {
-        "lines": 40
+        "lines": 60
       }
     },
     "modulePathIgnorePatterns": [


### PR DESCRIPTION
This PR updates the coverage threshold for codecov and Jest.

It changes the threshold to 60 for Jest meaning the unit tests must hit at least 60% coverage or it will fail.

It also turns off the patch requirement for codecov. We do this because sometimes PRs touch files in minor areas that have yet to be tested resulting in the patch requirement failing even if the author increased coverage in other areas. In the future, we can turn this back on.

It also changes the range to 40-70 meaning above 70% codecov will be green, less than 40 will be red and anything in between will approach green. We do this so the badge isn't read in the `README` and it's a reminder that we are indeed making progress on the code coverage increase.

Read more in the [codecov docs](https://docs.codecov.com/docs/coverage-configuration#range).