### PR TITLE
docs(install): Fix link to helm readme

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -234,7 +234,7 @@ alternative](https://hub.docker.com/r/linuxserver/code-server).
 
 ## Helm
 
-You can install code-server via [Helm](../ci/helm-chart/README.md).
+You can install code-server via [Helm](https://github.com/cdr/code-server/blob/main/ci/helm-chart/README.md).
 
 ## Raspberry Pi
 


### PR DESCRIPTION
Fixes #3867 
