### PR TITLE
Query artifacts by branch name

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -57,8 +57,8 @@ arch() {
 # https://developer.github.com/v3/actions/workflow-runs/#list-workflow-runs
 get_artifacts_url() {
   local artifacts_url
-  local workflow_runs_url="repos/:owner/:repo/actions/workflows/ci.yaml/runs?event=pull_request"
   local version_branch="v$VERSION"
+  local workflow_runs_url="repos/:owner/:repo/actions/workflows/ci.yaml/runs?event=pull_request&branch=$version_branch"
   artifacts_url=$(gh api "$workflow_runs_url" | jq -r ".workflow_runs[] | select(.head_branch == \"$version_branch\") | .artifacts_url" | head -n 1)
   if [[ -z "$artifacts_url" ]]; then
     echo >&2 "ERROR: artifacts_url came back empty"


### PR DESCRIPTION
This way workflows will still work even if there have been enough runs
to push the version branch run off the first page.
