### PR TITLE
fix(lib/vscode): patch authority in asWebviewUri

### DIFF
--- a/lib/vscode/src/vs/workbench/api/common/shared/webview.ts
+++ b/lib/vscode/src/vs/workbench/api/common/shared/webview.ts
@@ -55,9 +55,12 @@ export function asWebviewUri(
 		});
 	}
 
+	// NOTE@coder: Add the port separately because if the port is in the domain the
+	// URL will be invalid and the browser will not request it.
+	const authorityUrl = new URL(`${resource.scheme}://${resource.authority}`);
 	return URI.from({
 		scheme: Schemas.https,
-		authority: `${resource.scheme}+${resource.authority}.${webviewRootResourceAuthority}`,
+		authority: `${resource.scheme}+${authorityUrl.hostname}.${webviewRootResourceAuthority}${authorityUrl.port ? (':' + authorityUrl.port) : ''}`,
 		path: resource.path,
 		fragment: resource.fragment,
 		query: resource.query,

--- a/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -256,7 +256,7 @@ async function processResourceRequest(event, requestUrl) {
 
 	const firstHostSegment = requestUrl.hostname.slice(0, requestUrl.hostname.length - (resourceBaseAuthority.length + 1));
 	const scheme = firstHostSegment.split('+', 1)[0];
-	const authority = firstHostSegment.slice(scheme.length + 1); // may be empty
+	const authority = firstHostSegment.slice(scheme.length + 1) + requestUrl.port ? (':' + requestUrl.port) : ''; // may be empty
 
 	for (const parentClient of parentClients) {
 		parentClient.postMessage({


### PR DESCRIPTION
This PR patches `asWebviewUri` in `lib/vscode/src/vs/workbench/api/common/shared/webview.ts` to remove  the port number from the `authority` field used to create the URI.

For now, we found that removing the port fixes the issue (resources load as expected in webviews), but long-term, we want to understand how this is meant to be used (having the port in the URI authority field).

Related:
- https://github.com/cdr/code-server/discussions/3883
- https://excalidraw.com/#json=6022466832957440,nM6CH8Ga9F2AiLSzjJ55-A

## Video 

Here is a video of an extension using a webview which loads both CSS and JS working.

https://user-images.githubusercontent.com/3806031/128255007-c342bf0f-f444-48be-84cd-fa8059995d33.mov



Fixes N/A

TODOS
- [x] fix audit-ci vulnerability in separate PR https://github.com/cdr/code-server/pull/3899
- [x] clone vscode
- [x] get tests working
- [x] submit new test for `asWebviewUri` https://github.com/microsoft/vscode/pull/130148