### PR TITLE
chore: bump tar with resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "postcss": "^8.2.1",
     "browserslist": "^4.16.5",
     "safe-buffer": "^5.1.1",
-    "vfile-message": "^2.0.2"
+    "vfile-message": "^2.0.2",
+    "argon2/@mapbox/node-pre-gyp/tar": "^6.1.3"
   },
   "dependencies": {
     "@coder/logger": "1.1.16",

--- a/test/package.json
+++ b/test/package.json
@@ -16,5 +16,8 @@
     "ts-jest": "^26.4.4",
     "@types/wtfnode": "^0.7.0",
     "wtfnode": "^0.9.0"
+  },
+  "resolutions": {
+    "argon2/@mapbox/node-pre-gyp/tar": "^6.1.3"
   }
 }

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -4392,10 +4392,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tar@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
-  integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
+tar@^6.1.0, tar@^6.1.3:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
+  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,10 +4882,10 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.0.tgz#d1724e9bcc04b977b18d5c573b333a2207229a83"
-  integrity sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
+tar@^6.1.0, tar@^6.1.3:
+  version "6.1.6"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
+  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
This fixes a vulnerability from `tar`, which comes from `argon2`.

- https://www.npmjs.com/advisories/1770
- https://www.npmjs.com/advisories/1771
