### PR TITLE
chore(ci): replace playwright gh action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -352,8 +352,8 @@ jobs:
         with:
           node-version: "14"
 
-      - name: Install playwright
-        uses: microsoft/playwright-github-action@v1
+      - name: Install playwright OS dependencies
+        run: npx playwright install-deps
 
       - name: Fetch dependencies from cache
         id: cache-yarn


### PR DESCRIPTION
This action is no longer needed, see README for the action here: https://github.com/microsoft/playwright-github-action#%EF%B8%8F-you-dont-need-this-github-action-%EF%B8%8F

The suggested way to install OS deps for playwright is simply:

```
npx playwright install-deps
```

Reference: https://playwright.dev/docs/ci/#github-actions