### PR TITLE
release: 3.11.1

### DIFF
--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -20,4 +20,4 @@ version: 1.0.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 3.11.0
+appVersion: 3.11.1

--- a/ci/helm-chart/README.md
+++ b/ci/helm-chart/README.md
@@ -1,6 +1,6 @@
 # code-server
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.11.0](https://img.shields.io/badge/AppVersion-3.11.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.11.1](https://img.shields.io/badge/AppVersion-3.11.1-informational?style=flat-square)
 
 [code-server](https://github.com/cdr/code-server) code-server is VS Code running
 on a remote server, accessible through the browser.
@@ -73,7 +73,7 @@ and their default values.
 | hostnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
 | image.repository | string | `"codercom/code-server"` |  |
-| image.tag | string | `"3.11.0"` |  |
+| image.tag | string | `"3.11.1"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.enabled | bool | `false` |  |
 | nameOverride | string | `""` |  |

--- a/ci/helm-chart/values.yaml
+++ b/ci/helm-chart/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: codercom/code-server
-  tag: '3.11.0'
+  tag: '3.11.1'
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # code-server
 
-[!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq) [![codecov](https://codecov.io/gh/cdr/code-server/branch/main/graph/badge.svg?token=5iM9farjnC)](https://codecov.io/gh/cdr/code-server) [![See v3.11.0 docs](https://img.shields.io/static/v1?label=Docs&message=see%20v3.11.0%20&color=blue)](https://github.com/cdr/code-server/tree/v3.11.0/docs)
+[!["GitHub Discussions"](https://img.shields.io/badge/%20GitHub-%20Discussions-gray.svg?longCache=true&logo=github&colorB=purple)](https://github.com/cdr/code-server/discussions) [!["Join us on Slack"](https://img.shields.io/badge/join-us%20on%20slack-gray.svg?longCache=true&logo=slack&colorB=brightgreen)](https://cdr.co/join-community) [![Twitter Follow](https://img.shields.io/twitter/follow/CoderHQ?label=%40CoderHQ&style=social)](https://twitter.com/coderhq) [![codecov](https://codecov.io/gh/cdr/code-server/branch/main/graph/badge.svg?token=5iM9farjnC)](https://codecov.io/gh/cdr/code-server) [![See v3.11.1 docs](https://img.shields.io/static/v1?label=Docs&message=see%20v3.11.1%20&color=blue)](https://github.com/cdr/code-server/tree/v3.11.1/docs)
 
 Run [VS Code](https://github.com/Microsoft/vscode) on any machine anywhere and
 access it in the browser.
@@ -30,7 +30,7 @@ There are three ways to get started:
    automates most of the process. The script uses the system package manager if
    possible.
 2. Manually [installing
-   code-server](https://coder.com/docs/code-server/v3.11.0/install)
+   code-server](https://coder.com/docs/code-server/v3.11.1/install)
 3. Using our one-click buttons and guides to [deploy code-server to a cloud
    provider](https://github.com/cdr/deploy-code-server) ⚡
 
@@ -51,7 +51,7 @@ When done, the install script prints out instructions for running and starting
 code-server.
 
 We also have an in-depth [setup and
-configuration](https://coder.com/docs/code-server/v3.11.0/guide) guide.
+configuration](https://coder.com/docs/code-server/v3.11.1/guide) guide.
 
 ### code-server --link
 
@@ -71,11 +71,11 @@ Proxying code-server, you can access your IDE at https://example.cdr.co
 ## Questions?
 
 See answers to [frequently asked
-questions](https://coder.com/docs/code-server/v3.11.0/FAQ).
+questions](https://coder.com/docs/code-server/v3.11.1/FAQ).
 
 ## Want to help?
 
-See [Contributing](https://coder.com/docs/code-server/v3.11.0/CONTRIBUTING) for
+See [Contributing](https://coder.com/docs/code-server/v3.11.1/CONTRIBUTING) for
 details.
 
 ## Hiring

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "versions": ["v3.11.0", "v3.10.2"],
+  "versions": ["v3.11.1", "v3.11.0"],
   "routes": [
     {
       "title": "Home",

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -9,7 +9,7 @@ At the minimum, we recommend:
 - 2 CPU cores
 
 You can use any Linux distribution, but [our
-docs](https://coder.com/docs/code-server/v3.11.0/guide) assume that you're using
+docs](https://coder.com/docs/code-server/v3.11.1/guide) assume that you're using
 Debian hosted by Google Cloud (see the following section for instructions on
 setting this up).
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # code-server's automatic install script.
-# See https://coder.com/docs/code-server/v3.11.0/install
+# See https://coder.com/docs/code-server/v3.11.1/install
 
 usage() {
   arg0="$0"
@@ -66,7 +66,7 @@ fall back to npm so on architectures without pre-built releases this will error.
 
 The installer will cache all downloaded assets into ~/.cache/code-server
 
-More installation docs are at https://coder.com/docs/code-server/v3.11.0/install
+More installation docs are at https://coder.com/docs/code-server/v3.11.1/install
 EOF
 }
 
@@ -433,7 +433,7 @@ install_npm() {
   fi
   echoerr "Please install npm or yarn to install code-server!"
   echoerr "You will need at least node v12 and a few C dependencies."
-  echoerr "See the docs https://coder.com/docs/code-server/v3.11.0/install#yarn-npm"
+  echoerr "See the docs https://coder.com/docs/code-server/v3.11.1/install#yarn-npm"
 
   exit 1
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-server",
   "license": "MIT",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "description": "Run VS Code on a remote server.",
   "homepage": "https://github.com/cdr/code-server",
   "bugs": {


### PR DESCRIPTION
<!-- Note: this variable $CODE_SERVER_VERSION_TO_UPDATE will be set when you run the release-prep.sh script with `yarn release:prep` -->

This PR is to generate a new release of `code-server` at `3.11.1`

## Screenshot

Tested locally and everything seems to be working

https://user-images.githubusercontent.com/3806031/128562304-e28a2871-4217-437a-9056-ebd519c4ae9b.mov


## TODOs

Follow "Publishing a release" steps in `ci/README.md`

<!-- Note some of these steps below are redundant since they're listed in the "Publishing a release" docs -->

- [ ] publish release and merge PR
- [ ] update the AUR package