### PR TITLE
chore: fix docs version to only use latest

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,5 +1,5 @@
 {
-  "versions": ["v3.11.1", "v3.11.0"],
+  "versions": ["v3.11.1"],
   "routes": [
     {
       "title": "Home",


### PR DESCRIPTION
This PR updates the `manifest.json` to only include the latest version in the `versions` key.

Originally, I was going to go with Bruno's suggestion of `v3.11.*` to include all patches but as Jonathan noted, we really only need to support the latest version in the docs (we don't have that many changes between versions).

Plus, using the specific version like `v3.11.1` means it will auto-update with your `release-prep` script. Using `v3.11.*` would make it more difficult.


Fixes https://github.com/cdr/code-server/pull/3903#issuecomment-894609513

