### PR TITLE
fix(lib/vscode): remove symlink in npm package

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -98,10 +98,6 @@ EOF
   # yarn to fetch node_modules if necessary without build scripts running.
   # We cannot use --no-scripts because we still want dependent package scripts to run.
   jq 'del(.scripts)' < "$VSCODE_SRC_PATH/package.json" > "$VSCODE_OUT_PATH/package.json"
-
-  pushd "$VSCODE_OUT_PATH"
-  symlink_asar
-  popd
 }
 
 main "$@"


### PR DESCRIPTION
This PR removes the symlink to `node_modules.asar` when packaging up for `npm` because as of recently, npm no longer allows symbolic links in packages (we also don't need it).

## Why are we doing this?

On Friday, August 6th, we released 3.11.1. 

The npm workflow did not work as expected leading to 3.11.1 **not** being published on npm, Homebrew, or AUR. We did some investigation and came to the conclusion something changed on the npm side with regard to symlinks in packages.

We spoke to someone today, August 9th from GitHub who confirmed our theory. 

> Hi Joe! Saw your tweet about symlinks in npm packages. We did make some changes here recently. Can you drop me a line so that we can work through how to support you?

A few of the maintainers chatted and we came to the conclusion that we can remove this symlink. 

> We `rm -f`  this symlink in the post-install and recreate it (to make sure it's correct) so the packaged link will never be used.

—@code-asher 

This PR removes that symlink.

## Why did we have this before?

If you take a look at [`lib.sh`](https://github.com/cdr/code-server/blob/main/ci/lib.sh#L108-L114), you'll see previous maintainers left a comment explaining why we do this.

> VS Code bundles some modules into an asar which is an archive format that
> works like tar. It then seems to get unpacked into node_modules.asar.
> 
> I don't know why they do this but all the dependencies they bundle already
> exist in node_modules so just symlink it. We have to do this since not only VS
> Code itself but also extensions will look specifically in this directory for
> files (like the ripgrep binary or the oniguruma wasm).

## You sure this won't break anything?

90% sure it shouldn't break anything because we actually remoe the symlink in the post-install and recreate it anyway so the one included in the npm package is never actually used.

There may be an edge case or two that we didn't anticipate but I (@jsjoeio) removed it, [published to npm](https://www.npmjs.com/package/@jsjoeio/code-server), tested locally and did not find any major issues.

## How I tested locally

1. `yarn`
2. `yarn build`
3. `yarn build:vscode`
4. `yarn release`
5. check for symlinks - `cd release && find . -type l -ls`

Then I tested the individual release:
1. `cd release`
2. `yarn`
3. `node .`

### Screenshot and video

![image](https://user-images.githubusercontent.com/3806031/128761225-c4fb6d34-cac2-4cef-b7f9-a61bc5e3e5f1.png)


https://user-images.githubusercontent.com/3806031/128762052-adab54c3-5976-45eb-85b4-fc715665ea5c.mov


Fixes N/A

Related:
- [the GitHub Action log where it broke](https://github.com/cdr/code-server/runs/3265912373?check_suite_focus=true)
- [our investigation notes](https://github.com/cdr/code-server/discussions/3920)
- [tweet asking for help](https://twitter.com/jsjoeio/status/1423773035010527235?s=20)

## Other notes

@jawnsy showed me this trick to find symlinked files in a directory.

```sh
find . -type l -ls
```

Helpful for debuggging this kind of thing.