### PR TITLE
Revert "fix(lib/vscode): patch authority in asWebviewUri"

### DIFF
--- a/lib/vscode/src/vs/workbench/api/common/shared/webview.ts
+++ b/lib/vscode/src/vs/workbench/api/common/shared/webview.ts
@@ -55,12 +55,9 @@ export function asWebviewUri(
 		});
 	}
 
-	// NOTE@coder: Add the port separately because if the port is in the domain the
-	// URL will be invalid and the browser will not request it.
-	const authorityUrl = new URL(`${resource.scheme}://${resource.authority}`);
 	return URI.from({
 		scheme: Schemas.https,
-		authority: `${resource.scheme}+${authorityUrl.hostname}.${webviewRootResourceAuthority}${authorityUrl.port ? (':' + authorityUrl.port) : ''}`,
+		authority: `${resource.scheme}+${resource.authority}.${webviewRootResourceAuthority}`,
 		path: resource.path,
 		fragment: resource.fragment,
 		query: resource.query,

--- a/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/lib/vscode/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -256,7 +256,7 @@ async function processResourceRequest(event, requestUrl) {
 
 	const firstHostSegment = requestUrl.hostname.slice(0, requestUrl.hostname.length - (resourceBaseAuthority.length + 1));
 	const scheme = firstHostSegment.split('+', 1)[0];
-	const authority = firstHostSegment.slice(scheme.length + 1) + requestUrl.port ? (':' + requestUrl.port) : ''; // may be empty
+	const authority = firstHostSegment.slice(scheme.length + 1); // may be empty
 
 	for (const parentClient of parentClients) {
 		parentClient.postMessage({


### PR DESCRIPTION
This PR reverts https://github.com/cdr/code-server/pull/3895

We had a misunderstanding and didn't realize the symlink is needed in standalone releases (because it doesn't have a postinstall step). So we need to rethink our approach for removing the symlink for only the npm package.
