### PR TITLE
Revert "Merge pull request #3935 from cdr/jsjoeio-rm-symlink"

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -98,6 +98,10 @@ EOF
   # yarn to fetch node_modules if necessary without build scripts running.
   # We cannot use --no-scripts because we still want dependent package scripts to run.
   jq 'del(.scripts)' < "$VSCODE_SRC_PATH/package.json" > "$VSCODE_OUT_PATH/package.json"
+
+  pushd "$VSCODE_OUT_PATH"
+  symlink_asar
+  popd
 }
 
 main "$@"


### PR DESCRIPTION
This PR reverts https://github.com/cdr/code-server/pull/3935

We had a misunderstanding and didn't realize the symlink is needed in standalone releases (because it doesn't have a postinstall step). So we need to rethink our approach for removing the symlink for only the npm package.
