### PR TITLE
chore: fix path-parse vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "browserslist": "^4.16.5",
     "safe-buffer": "^5.1.1",
     "vfile-message": "^2.0.2",
-    "argon2/@mapbox/node-pre-gyp/tar": "^6.1.3"
+    "argon2/@mapbox/node-pre-gyp/tar": "^6.1.3",
+    "path-parse": "^1.0.7"
   },
   "dependencies": {
     "@coder/logger": "1.1.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3769,10 +3769,10 @@ path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+path-parse@^1.0.6, path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-platform@~0.11.15:
   version "0.11.15"


### PR DESCRIPTION
This PR resolves a vulnerability with `path-parse`.

https://www.npmjs.com/advisories/1773