### PR TITLE
fix(readme): tls docs path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ configuration](https://coder.com/docs/code-server/v3.11.1/guide) guide.
 
 ## TLS and authentication (beta)
 
-To add TLS and authentication out of the box, use [code-server --link](https://coder.com/docs/code-server/v3.11.0/link).
+To add TLS and authentication out of the box, use [code-server --link](https://coder.com/docs/code-server/v3.11.1/link).
 
 ## Questions?
 


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

The link to the `--link` docs that relate to TLS is broken (404) as it is pointing to a previous release version whose docs are not available.
This PR updates the docs URL.

I've also run a search on the project to make sure no other links using that version where there and I haven't found any.

As an extra, I'd suggest using the `latest` path rather than a specific version

p.s. I've skipped creating an issue as per docs:
_Please create a GitHub Issue that includes context for issues that you see. **You can skip this if the proposed fix is minor.**_