### PR TITLE
fix: add symlink to npmignore

### DIFF
--- a/ci/steps/publish-npm.sh
+++ b/ci/steps/publish-npm.sh
@@ -20,6 +20,10 @@ main() {
   download_artifact npm-package ./release-npm-package
   # https://github.com/actions/upload-artifact/issues/38
   tar -xzf release-npm-package/package.tar.gz
+
+  # Ignore symlink when publishing npm package
+  # See: https://github.com/cdr/code-server/pull/3935
+  echo "node_modules.asar" > release/.npmignore
   yarn publish --non-interactive release
 }
 


### PR DESCRIPTION
This PR modifies the `publish-npm.sh` to add an `.npmignore` with a line to exclude the symlink `node_modules.asar` in the npm release.

## Why are we doing this?

As you may have see in the [3.11.1 discussion](https://github.com/cdr/code-server/discussions/3920), we had a hiccup publishing the latest version to npm/Homebrew. This is because npm recently made a change to their package requirements, disallowing symlinks in packages.

Fortunately, we don't need the symlink in the npm package release of code-server. 

We originally thought we could remove the symlink all together, but after chatting with @code-asher, we realized we still need it for the standalone releases. 

### Fixing it

We had two options to fix it:
1. copy `.gitignore` to the npm package before bundling up
2. add [`.npmignore`](https://npm.github.io/publishing-pkgs-docs/publishing/the-npmignore-file.html) to the npm package and include the symlink

We opted to go with Option 2 because:
- it's a single line in the `publish-npm.sh`
- it's a solution that's isolating to the problem (i.e. copying the `.gitignore` could have unintended consequences)

## Test plan

1. make changes
2. build a release, e.g. what we publish on npm
3. try publishing under individual scope ([@jsjoeio/code-server](https://www.npmjs.com/package/@jsjoeio/code-server))
4. test locally to ensure code-servers works, including ripgrep (used in file search)

https://user-images.githubusercontent.com/3806031/129079872-9f4862ff-d759-4752-81e4-3bf0a6333a6f.mov

Fixes N/A

Related:
- https://github.com/cdr/code-server/pull/3949
- https://github.com/cdr/code-server/pull/3935