### PR TITLE
improve npm/yarn install flow and add Windows 10 instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -230,7 +230,7 @@ You can install code-server via [Helm](https://github.com/cdr/code-server/blob/m
 We currently do not publish windows releases (see [#1397](https://github.com/cdr/code-server/issues/1397)). We recommend installing code-server onto Raspberry Pi with [`yarn` or
 `npm`](#yarn-npm).
 
-> Note: coder --link does not work with Windows at this time.
+> Note: You will also need to [build cdr/cloud-agent manually](https://github.com/cdr/cloud-agent/issues/17) if you would like to use `code-server --link` on Windows.
 
 ## Raspberry Pi
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -230,6 +230,8 @@ You can install code-server via [Helm](https://github.com/cdr/code-server/blob/m
 We currently do not publish windows releases (see [#1397](https://github.com/cdr/code-server/issues/1397)). We recommend installing code-server onto Raspberry Pi with [`yarn` or
 `npm`](#yarn-npm).
 
+> Note: coder --link does not work with Windows at this time.
+
 ## Raspberry Pi
 
 We recommend installing code-server onto Raspberry Pi with [`yarn` or

--- a/docs/install.md
+++ b/docs/install.md
@@ -228,7 +228,7 @@ You can install code-server via [Helm](https://github.com/cdr/code-server/blob/m
 
 ## Windows
 
-We currently do not publish Windows releases (see [#1397](https://github.com/cdr/code-server/issues/1397)). We recommend installing code-server onto Windows with [`yarn` or
+We currently [do not publish Windows releases](https://github.com/cdr/code-server/issues/1397). We recommend installing code-server onto Windows with [`yarn` or
 `npm`](#yarn-npm).
 
 > Note: You will also need to [build cdr/cloud-agent manually](https://github.com/cdr/cloud-agent/issues/17) if you would like to use `code-server --link` on Windows.

--- a/docs/install.md
+++ b/docs/install.md
@@ -228,7 +228,7 @@ You can install code-server via [Helm](https://github.com/cdr/code-server/blob/m
 
 ## Windows
 
-We currently do not publish windows releases (see [#1397](https://github.com/cdr/code-server/issues/1397)). We recommend installing code-server onto Raspberry Pi with [`yarn` or
+We currently do not publish Windows releases (see [#1397](https://github.com/cdr/code-server/issues/1397)). We recommend installing code-server onto Windows with [`yarn` or
 `npm`](#yarn-npm).
 
 > Note: You will also need to [build cdr/cloud-agent manually](https://github.com/cdr/cloud-agent/issues/17) if you would like to use `code-server --link` on Windows.

--- a/docs/install.md
+++ b/docs/install.md
@@ -99,27 +99,16 @@ _exact_ same commands presented in the rest of this document.
 We recommend installing with `yarn` or `npm` when:
 
 1. You aren't using a machine with `amd64` or `arm64`.
-2. You're on Linux with `glibc` < v2.17, `glibcxx` < v3.4.18 on `amd64`, `glibc`
+1. You are installing code-server on Windows
+1. You're on Linux with `glibc` < v2.17, `glibcxx` < v3.4.18 on `amd64`, `glibc`
    < v2.23, or `glibcxx` < v3.4.21 on `arm64`.
-3. You're running Alpine Linux or are using a non-glibc libc. See
+1. You're running Alpine Linux or are using a non-glibc libc. See
    [#1430](https://github.com/cdr/code-server/issues/1430#issuecomment-629883198)
    for more information.
 
 Installing code-server with `yarn` or `npm` builds native modules on install.
-This process requires C dependencies; see our guide on [installing these
-dependencies][./npm.md](./npm.md) for more information.
 
-You must have Node.js v12 (or later) installed. See
-[#1633](https://github.com/cdr/code-server/issues/1633).
-
-To install:
-
-```bash
-yarn global add code-server
-# Or: npm install -g code-server
-code-server
-# Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
-```
+This process requires C dependencies; see our guide on [installing with yarn and npm][./npm.md](./npm.md) for more information.
 
 ## Standalone releases
 
@@ -235,6 +224,11 @@ alternative](https://hub.docker.com/r/linuxserver/code-server).
 ## Helm
 
 You can install code-server via [Helm](https://github.com/cdr/code-server/blob/main/ci/helm-chart/README.md).
+
+## Windows
+
+We currently do not publish windows releases (see [#1397](https://github.com/cdr/code-server/issues/1397)). We recommend installing code-server onto Raspberry Pi with [`yarn` or
+`npm`](#yarn-npm).
 
 ## Raspberry Pi
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,7 @@
 - [macOS](#macos)
 - [Docker](#docker)
 - [Helm](#helm)
+- [Windows](#windows)
 - [Raspberry Pi](#raspberry-pi)
 - [Termux](#termux)
 - [Cloud providers](#cloud-providers)

--- a/docs/install.md
+++ b/docs/install.md
@@ -228,8 +228,7 @@ You can install code-server via [Helm](https://github.com/cdr/code-server/blob/m
 
 ## Windows
 
-We currently [do not publish Windows releases](https://github.com/cdr/code-server/issues/1397). We recommend installing code-server onto Windows with [`yarn` or
-`npm`](#yarn-npm).
+We currently [do not publish Windows releases](https://github.com/cdr/code-server/issues/1397). We recommend installing code-server onto Windows with [`yarn` or `npm`](#yarn-npm).
 
 > Note: You will also need to [build cdr/cloud-agent manually](https://github.com/cdr/cloud-agent/issues/17) if you would like to use `code-server --link` on Windows.
 

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-# yarn, npm
+# npm Install Requirements
 
 - [Node.js version](#nodejs-version)
 - [Ubuntu, Debian](#ubuntu-debian)
@@ -8,7 +8,10 @@
 - [Alpine](#alpine)
 - [macOS](#macos)
 - [FreeBSD](#freebsd)
-- [Issues with Node.js after version upgrades](#issues-with-nodejs-after-version-upgrades)
+- [Windows](#windows)
+- [Installing](#installing)
+- [Troubleshooting](#troubleshooting)
+  - [Issues with Node.js after version upgrades](#issues-with-nodejs-after-version-upgrades)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -1,6 +1,6 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-# npm Install Requirements
+# yarn, npm
 
 - [Node.js version](#nodejs-version)
 - [Ubuntu, Debian](#ubuntu-debian)
@@ -35,6 +35,8 @@ sudo apt-get install -y \
 npm config set python python3
 ```
 
+Proceed to [installing](#installing)
+
 ## Fedora, CentOS, RHEL
 
 ```bash
@@ -44,6 +46,8 @@ sudo yum install -y python2
 npm config set python python2
 ```
 
+Proceed to [installing](#installing)
+
 ## Alpine
 
 ```bash
@@ -51,11 +55,15 @@ apk add alpine-sdk bash libstdc++ libc6-compat
 npm config set python python3
 ```
 
+Proceed to [installing](#installing)
+
 ## macOS
 
 ```bash
 xcode-select --install
 ```
+
+Proceed to [installing](#installing)
 
 ## FreeBSD
 
@@ -64,7 +72,49 @@ pkg install -y git python npm-node14 yarn-node14 pkgconf
 pkg install -y libinotify
 ```
 
-## Issues with Node.js after version upgrades
+Proceed to [installing](#installing)
+
+## Windows
+
+Installing code-server requires all of the [prerequisites for VS Code development](https://github.com/Microsoft/vscode/wiki/How-to-Contribute#prerequisites). When installing the C++ compiler tool chain, we recommend using "Option 2: Visual Studio 2019" for best results.
+
+Next, install code-server with:
+
+```bash
+yarn global add code-server
+# Or: npm install -g code-server
+code-server
+# Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
+```
+
+A `postinstall.sh` script will attempt to run. Select your terminal (e.g git bash) as the default application for .sh files. If an additional dialog does not appear, run the install command again.
+
+If the `code-server` command is not found, you'll need to [add a directory to your PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/). To find the directory, use the following commands:
+
+```shell
+yarn global bin
+# Or: npm config get prefix
+```
+
+For help and additional troubleshooting, see [#1397](https://github.com/cdr/code-server/issues/1397).
+
+## Installing
+
+After adding the dependencies for your OS, install code-server package globally:
+
+```bash
+yarn global add code-server
+# Or: npm install -g code-server
+code-server
+# Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
+```
+
+## Troubleshooting
+
+If you need further assistance, post on our [GitHub Discussions
+page](https://github.com/cdr/code-server/discussions).
+
+### Issues with Node.js after version upgrades
 
 Occasionally, you may run into issues with Node.js.
 
@@ -79,6 +129,3 @@ A step-by-step example of how you might do this is:
 2. Navigate into the directory: `cd /usr/local/Cellar/code-server/<version>/libexec/lib/vscode/`
 3. Recompile the native modules: `npm rebuild`
 4. Restart code-server
-
-If you need further assistance, post on our [GitHub Discussions
-page](https://github.com/cdr/code-server/discussions).

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -90,7 +90,7 @@ code-server
 # Now visit http://127.0.0.1:8080. Your password is in ~/.config/code-server/config.yaml
 ```
 
-A `postinstall.sh` script will attempt to run. Select your terminal (e.g git bash) as the default application for .sh files. If an additional dialog does not appear, run the install command again.
+A `postinstall.sh` script will attempt to run. Select your terminal (e.g., Git bash) as the default application for `.sh` files. If an additional dialog does not appear, run the install command again.
 
 If the `code-server` command is not found, you'll need to [add a directory to your PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/). To find the directory, use the following command:
 

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -103,7 +103,7 @@ For help and additional troubleshooting, see [#1397](https://github.com/cdr/code
 
 ## Installing
 
-After adding the dependencies for your OS, install code-server package globally:
+After adding the dependencies for your OS, install the code-server package globally:
 
 ```bash
 yarn global add code-server

--- a/docs/npm.md
+++ b/docs/npm.md
@@ -89,7 +89,7 @@ code-server
 
 A `postinstall.sh` script will attempt to run. Select your terminal (e.g git bash) as the default application for .sh files. If an additional dialog does not appear, run the install command again.
 
-If the `code-server` command is not found, you'll need to [add a directory to your PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/). To find the directory, use the following commands:
+If the `code-server` command is not found, you'll need to [add a directory to your PATH](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/). To find the directory, use the following command:
 
 ```shell
 yarn global bin


### PR DESCRIPTION
The user flow for our npm docs were slightly confusing to me. While there was a dedicated page for the npm prerequisites, the install command itself was on install.md. This PR moves all of the steps to npm.md.

Windows 10 instructions were also added to this PR since it benefits from the improved docs structure, as there are quite a few "gotchas" with installing on Windows, which have now been documented. It also links to #1397, to centralize issues & discussions around additional support for Windows.