### PR TITLE
chore: add stale bot

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,12 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 180
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 5
+# Label to apply when stale.
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no activity occurs in the next 5 days.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
@jawnsy brought this up the other day. Then GitHub mentioned we should it so I thought why not 🤷‍♂️

I will take responsibility if it goes horribly wrong 😂

The way this works is we have a `stale.yml` under `.github` which is the configuration and then @jawnsy enabled [Stale bot](https://github.com/probot/probot) it at the `cdr` org level. 

Fixes N/A