### PR TITLE
fix: remove stale label action from ranger

### DIFF
--- a/.github/ranger.yml
+++ b/.github/ranger.yml
@@ -15,10 +15,6 @@ labels:
   "squash when passing": merge
   "rebase when passing": merge
   "merge when passing": merge
-  stale:
-    action: close
-    delay: 7 days
-    comment: "⚠️ This issue has been marked stale and will automatically be closed in $DELAY."
   "new contributor":
     action: comment
     delay: 5s


### PR DESCRIPTION
This PR fixes Ranger config to not close issues with `stale`. Instead, we'll leave those to Stale bot.