### PR TITLE
fix: revert revert and add ssh back into guide docs

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -15,6 +15,9 @@
   - [Stripping `/proxy/<port>` from the request path](#stripping-proxyport-from-the-request-path)
   - [Proxying to create a React app](#proxying-to-create-a-react-app)
   - [Proxying to a Vue app](#proxying-to-a-vue-app)
+- [SSH into code-server on VS Code](#ssh-into-code-server-on-vs-code)
+  - [Option 1: cloudflared tunnel](#option-1-cloudflared-tunnel)
+  - [Option 2: ngrok tunnel](#option-2-ngrok-tunnel)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -370,3 +373,91 @@ module.exports = {
 3. access app at `<code-server-root>/absproxy/3454` e.g. `http://localhost:8080/absproxy/3454`
 
 Read more about `publicPath` in the [Vue.js docs](https://cli.vuejs.org/config/#publicpath)
+
+## SSH into code-server on VS Code
+
+[![SSH](https://img.shields.io/badge/SSH-363636?style=for-the-badge&logo=GNU+Bash&logoColor=ffffff)](https://ohmyz.sh/) [![Terminal](https://img.shields.io/badge/Terminal-2E2E2E?style=for-the-badge&logo=Windows+Terminal&logoColor=ffffff)](https://img.shields.io/badge/Terminal-2E2E2E?style=for-the-badge&logo=Windows+Terminal&logoColor=ffffff) [![Visual Studio Code](https://img.shields.io/badge/Visual_Studio_Code-007ACC?style=for-the-badge&logo=Visual+Studio+Code&logoColor=ffffff)](vscode:extension/ms-vscode-remote.remote-ssh)
+
+Follow these steps where code-server is running:
+
+1. Install `openssh-server`, `wget`, and `unzip`.
+
+```bash
+# example for Debian and Ubuntu operating systems
+sudo apt update
+sudo apt install wget unzip openssh-server
+```
+
+2. Start the SSH server and set the password for your user, if you haven't already. If you use [deploy-code-server](https://github.com/cdr/deploy-code-server),
+
+```bash
+sudo service ssh start
+sudo passwd {user} # replace user with your code-server user
+```
+
+### Option 1: cloudflared tunnel
+
+[![Cloudflared](https://img.shields.io/badge/Cloudflared-E4863B?style=for-the-badge&logo=cloudflare&logoColor=ffffff)](https://github.com/cloudflare/cloudflared)
+
+1.  Install [cloudflared](https://github.com/cloudflare/cloudflared#installing-cloudflared) on your local computer
+2.  Then go to `~/.ssh/config` and add the following:
+
+```shell
+Host *.trycloudflare.com
+HostName %h
+User root
+Port 22
+ProxyCommand "cloudflared location" access ssh --hostname %h
+```
+
+3. Run `cloudflared tunnel --url ssh://localhost:22` on the remote server
+
+4. Finally on VS Code or any IDE that supports SSH, run `ssh coder@https://your-link.trycloudflare.com` or `ssh coder@your-link.trycloudflare.com`
+
+### Option 2: ngrok tunnel
+
+[![Ngrok](https://img.shields.io/badge/Ngrok-1F1E37?style=for-the-badge&logo=ngrok&logoColor=ffffff)](https://ngrok.com/)
+
+1.  Make a new account for ngrok [here](https://dashboard.ngrok.com/login)
+
+2.  Now, get the ngrok binary with `wget` and unzip it with `unzip`:
+
+```bash
+wget "https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip"
+unzip "ngrok-stable-linux-amd64.zip"
+```
+
+5.  Then, go to [dashboard.ngrok.com](https://dashboard.ngrok.com) and go to the `Your Authtoken` section.
+6.  Copy the Authtoken shown there.
+7.  Now, go to the folder where you unzipped ngrok and store the Authtoken from the ngrok Dashboard.
+
+```bash
+./ngrok authtoken YOUR_AUTHTOKEN # replace YOUR_AUTHTOKEN with the ngrok authtoken.
+```
+
+8.  Now, forward port 22, which is the SSH port with this command:
+
+```bash
+./ngrok tcp 22
+```
+
+Now, you get a screen in the terminal like this:
+
+```console
+ngrok by @inconshreveable(Ctrl+C to quit)
+
+Session Status                online
+Account                       {Your name} (Plan: Free)
+Version                       2.3.40
+Region                        United States (us)
+Web Interface                 http://127.0.0.1:4040
+Forwarding                    tcp://0.tcp.ngrok.io:19028 -> localhost:22
+```
+
+Copy the forwarded link `0.tcp.ngrok.io` and remember the port number `19028`. Type this on your local Visual Studio Code:
+
+```bash
+ssh user@0.tcp.ngrok.io -p 19028
+```
+
+The port redirects you to the default SSH port 22, and you can then successfully connect to code-server by entering the password you set for the user.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -454,10 +454,12 @@ Web Interface                 http://127.0.0.1:4040
 Forwarding                    tcp://0.tcp.ngrok.io:19028 -> localhost:22
 ```
 
-Copy the forwarded link `0.tcp.ngrok.io` and remember the port number `19028`. Type this on your local Visual Studio Code:
+In this case, copy the forwarded link `0.tcp.ngrok.io` and remember the port number `19028`. Type this on your local Visual Studio Code:
 
 ```bash
 ssh user@0.tcp.ngrok.io -p 19028
 ```
 
 The port redirects you to the default SSH port 22, and you can then successfully connect to code-server by entering the password you set for the user.
+
+Note: the port and the url provided by ngrok will change each time you run it so modify as needed.

--- a/lib/vscode/package.json
+++ b/lib/vscode/package.json
@@ -218,6 +218,7 @@
     "elliptic": "^6.5.3",
     "nwmatcher": "^1.4.4",
     "chrome-remote-interface": "^0.30.0",
-    "glob-parent": "^5.1.2"
+    "glob-parent": "^5.1.2",
+    "tar": "^6.1.9"
   }
 }

--- a/lib/vscode/yarn.lock
+++ b/lib/vscode/yarn.lock
@@ -8020,10 +8020,10 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar@^6.0.2:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
-  integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
+tar@^6.0.2, tar@^6.1.9:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "browserslist": "^4.16.5",
     "safe-buffer": "^5.1.1",
     "vfile-message": "^2.0.2",
-    "argon2/@mapbox/node-pre-gyp/tar": "^6.1.3",
+    "argon2/@mapbox/node-pre-gyp/tar": "^6.1.9",
     "path-parse": "^1.0.7"
   },
   "dependencies": {

--- a/test/package.json
+++ b/test/package.json
@@ -19,6 +19,6 @@
     "wtfnode": "^0.9.0"
   },
   "resolutions": {
-    "argon2/@mapbox/node-pre-gyp/tar": "^6.1.3"
+    "argon2/@mapbox/node-pre-gyp/tar": "^6.1.9"
   }
 }

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -4412,10 +4412,10 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-tar@^6.1.0, tar@^6.1.3:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
-  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
+tar@^6.1.0, tar@^6.1.9:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4882,10 +4882,10 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^6.1.0, tar@^6.1.3:
-  version "6.1.6"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.6.tgz#c23d797b0a1efe5d479b1490805c5443f3560c5d"
-  integrity sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==
+tar@^6.1.0, tar@^6.1.9:
+  version "6.1.11"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.1.11.tgz#6760a38f003afa1b2ffd0ffe9e9abbd0eab3d621"
+  integrity sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==
   dependencies:
     chownr "^2.0.0"
     fs-minipass "^2.0.0"


### PR DESCRIPTION
#4042 broke our docs website, #4060 reverted the change.

> There are 2 problems in there. There are 4 back ticks at the end of one block. Changing the line “```output” to  “```console” should fix it

Thanks to @mterhar, I think we found the issue. 

We're working with @BrunoQuaresma to prevent issues like this in the future.

Related:
- https://github.com/cdr/code-server/pull/4042
- https://github.com/cdr/code-server/pull/4060
- https://github.com/cdr/code-server/discussions/4057