### PR TITLE
fix: run postinstall script explicitly with bash

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -48,7 +48,7 @@ bundle_code_server() {
   {
     "commit": "$(git rev-parse HEAD)",
     "scripts": {
-      "postinstall": "./postinstall.sh"
+      "postinstall": "bash ./postinstall.sh"
     }
   }
 EOF


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Currently, Windows default script-shell (cmd) fails to run the postinstall script.

This commit fixes the problem by running postinstall.sh explicitly with the default bash executable of the OS.

Related: #1397