### PR TITLE
fix(lib/vscode): update csp in webview to allow ports

### DIFF
--- a/lib/vscode/src/vs/workbench/api/common/shared/webview.ts
+++ b/lib/vscode/src/vs/workbench/api/common/shared/webview.ts
@@ -24,7 +24,10 @@ export const webviewResourceBaseHost = 'vscode-webview.net';
 
 export const webviewRootResourceAuthority = `vscode-resource.${webviewResourceBaseHost}`;
 
-export const webviewGenericCspSource = `https://*.${webviewResourceBaseHost}`;
+// NOTE@coder: This is a temporary change to include ":*"
+// due to the patch we had to make for webview resources.
+// See PR#3895 and https://github.com/cdr/code-server/issues/3936 for more details.
+export const webviewGenericCspSource = `https://*.${webviewResourceBaseHost}:*`;
 
 /**
  * Construct a uri that can load resources inside a webview


### PR DESCRIPTION
With #3895, we caused a regression where the Content-Security-Policy prevented
images in the previewer to not work due to the ports in the resource URI.

This modifies the CSP in the webview to make sure images are not blocked by CSP.

I assume once we upgrade VS Code, we will revert this change.

## Screeshot

![](https://user-images.githubusercontent.com/3806031/132780618-58f2c1df-22b0-42f7-823d-6402d7b5983d.png)

See notes here: https://github.com/cdr/code-server/issues/3936#issuecomment-916518450

Fixes #3936 #4098


## TODOs

- [x] test locally and see if this also fixes https://github.com/cdr/code-server/issues/4098

Looks like this PR is a two-for-one!

![image](https://user-images.githubusercontent.com/3806031/132895627-dfa1ad4f-550c-4470-9c9c-e5d0b749138f.png)
