### PR TITLE
fix(codecov): use status > patch correctly

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,7 +6,8 @@ coverage:
   precision: 2
   round: down
   range: "40...70"
-  patch: off
+  status:
+    patch: off
 
 parsers:
   gcov:


### PR DESCRIPTION
I thought I fixed this in a previous PR but I guess not. I can't seem to find it. Turns out, our codecov was technically invalid because we weren't using `patch: off` under `status`.

To prevent this in the future, validate the codecov:

```shell
cd .github && curl --data-binary @codecov.yml https://codecov.io/validate
```

Fixes N/A
