### PR TITLE
feat: add tests for src/node/app.ts

### DIFF
--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -524,3 +524,12 @@ export function escapeHtml(unsafe: string): string {
     .replace(/"/g, "&quot;")
     .replace(/'/g, "&apos;")
 }
+
+/**
+ * A helper function which returns a boolean indicating whether
+ * the given error is a NodeJS.ErrnoException by checking if
+ * it has a .code property.
+ */
+export function isNodeJSErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && (error as NodeJS.ErrnoException).code !== undefined
+}

--- a/test/unit/node/__snapshots__/app.test.ts.snap
+++ b/test/unit/node/__snapshots__/app.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`handleServerError should log an error if resolved is true 1`] = `"Cannot read property 'handle' of undefined"`;

--- a/test/unit/node/app.test.ts
+++ b/test/unit/node/app.test.ts
@@ -1,6 +1,168 @@
+import { logger } from "@coder/logger"
+import { promises, rmdirSync } from "fs"
 import * as http from "http"
-import { ensureAddress } from "../../../src/node/app"
-import { getAvailablePort } from "../../utils/helpers"
+import * as https from "https"
+import * as path from "path"
+import { createApp, ensureAddress, handleArgsSocketCatchError, handleServerError } from "../../../src/node/app"
+import { OptionalString, setDefaults } from "../../../src/node/cli"
+import { generateCertificate } from "../../../src/node/util"
+import { getAvailablePort, tmpdir } from "../../utils/helpers"
+
+describe("createApp", () => {
+  let spy: jest.SpyInstance
+  let unlinkSpy: jest.SpyInstance
+  let port: number
+  let tmpDirPath: string
+  let tmpFilePath: string
+
+  beforeAll(async () => {
+    tmpDirPath = await tmpdir("unlink-socket")
+    tmpFilePath = path.join(tmpDirPath, "unlink-socket-file")
+  })
+
+  beforeEach(async () => {
+    spy = jest.spyOn(logger, "error")
+    // NOTE:@jsjoeio
+    // Be mindful when spying.
+    // You can't spy on fs functions if you do import * as fs
+    // You have to import individually, like we do here with promises
+    // then you can spy on those modules methods, like unlink.
+    // See: https://github.com/aelbore/esbuild-jest/issues/26#issuecomment-893763840
+    unlinkSpy = jest.spyOn(promises, "unlink")
+    port = await getAvailablePort()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+    // Ensure directory was removed
+    rmdirSync(tmpDirPath, { recursive: true })
+  })
+
+  it("should return an Express app, a WebSockets Express app and an http server", async () => {
+    const defaultArgs = await setDefaults({
+      port,
+      _: [],
+    })
+    const [app, wsApp, server] = await createApp(defaultArgs)
+
+    // This doesn't check much, but it's a good sanity check
+    // to ensure we actually get back values from createApp
+    expect(app).not.toBeNull()
+    expect(wsApp).not.toBeNull()
+    expect(server).toBeInstanceOf(http.Server)
+
+    // Cleanup
+    server.close()
+  })
+
+  it("should handle error events on the server", async () => {
+    const defaultArgs = await setDefaults({
+      port,
+      _: [],
+    })
+
+    // This looks funky, but that's because createApp
+    // returns an array like [app, wsApp, server]
+    // We only need server which is at index 2
+    // we do it this way so ESLint is happy that we're
+    // have no declared variables not being used
+    const app = await createApp(defaultArgs)
+    const server = app[2]
+
+    const testError = new Error("Test error")
+    // We can easily test how the server handles errors
+    // By emitting an error event
+    // Ref: https://stackoverflow.com/a/33872506/3015595
+    server.emit("error", testError)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(`http server error: ${testError.message} ${testError.stack}`)
+
+    // Cleanup
+    server.close()
+  })
+
+  it("should reject errors that happen before the server can listen", async () => {
+    // We listen on an invalid port
+    // causing the app to reject the Promise called at startup
+    const port = 2
+    const defaultArgs = await setDefaults({
+      port,
+      _: [],
+    })
+
+    async function masterBall() {
+      const app = await createApp(defaultArgs)
+      const server = app[2]
+
+      const testError = new Error("Test error")
+
+      server.emit("error", testError)
+
+      // Cleanup
+      server.close()
+    }
+
+    expect(() => masterBall()).rejects.toThrow(`listen EACCES: permission denied 127.0.0.1:${port}`)
+  })
+
+  it("should unlink a socket before listening on the socket", async () => {
+    await promises.writeFile(tmpFilePath, "")
+    const defaultArgs = await setDefaults({
+      _: [],
+      socket: tmpFilePath,
+    })
+
+    const app = await createApp(defaultArgs)
+    const server = app[2]
+
+    expect(unlinkSpy).toHaveBeenCalledTimes(1)
+    server.close()
+  })
+  it("should catch errors thrown when unlinking a socket", async () => {
+    const tmpDir2 = await tmpdir("unlink-socket-error")
+    const tmpFile = path.join(tmpDir2, "unlink-socket-file")
+    // await promises.writeFile(tmpFile, "")
+    const socketPath = tmpFile
+    const defaultArgs = await setDefaults({
+      _: [],
+      socket: socketPath,
+    })
+
+    const app = await createApp(defaultArgs)
+    const server = app[2]
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(`ENOENT: no such file or directory, unlink '${socketPath}'`)
+
+    server.close()
+    // Ensure directory was removed
+    rmdirSync(tmpDir2, { recursive: true })
+  })
+
+  it("should create an https server if args.cert exists", async () => {
+    const testCertificate = await generateCertificate("localhost")
+    const cert = new OptionalString(testCertificate.cert)
+    const defaultArgs = await setDefaults({
+      port,
+      cert,
+      _: [],
+      ["cert-key"]: testCertificate.certKey,
+    })
+    const app = await createApp(defaultArgs)
+    const server = app[2]
+
+    // This doesn't check much, but it's a good sanity check
+    // to ensure we actually get an https.Server
+    expect(server).toBeInstanceOf(https.Server)
+
+    // Cleanup
+    server.close()
+  })
+})
 
 describe("ensureAddress", () => {
   let mockServer: http.Server
@@ -26,5 +188,109 @@ describe("ensureAddress", () => {
     mockServer.address = () => "http://localhost:8080"
     const address = ensureAddress(mockServer)
     expect(address).toBe(`http://localhost:8080`)
+  })
+})
+
+describe("handleServerError", () => {
+  let spy: jest.SpyInstance
+
+  beforeEach(() => {
+    spy = jest.spyOn(logger, "error")
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("should call reject if resolved is false", async () => {
+    const resolved = false
+    const reject = jest.fn((err: Error) => undefined)
+    const error = new Error("handleServerError Error")
+
+    handleServerError(resolved, error, reject)
+
+    expect(reject).toHaveBeenCalledTimes(1)
+    expect(reject).toHaveBeenCalledWith(error)
+  })
+
+  it("should log an error if resolved is true", async () => {
+    const resolved = true
+    const reject = jest.fn((err: Error) => undefined)
+    const error = new Error("handleServerError Error")
+
+    handleServerError(resolved, error, reject)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toThrowErrorMatchingSnapshot()
+  })
+})
+
+describe("handleArgsSocketCatchError", () => {
+  let spy: jest.SpyInstance
+
+  beforeEach(() => {
+    spy = jest.spyOn(logger, "error")
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("should log an error if its not an NodeJS.ErrnoException", () => {
+    const error = new Error()
+
+    handleArgsSocketCatchError(error)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(error)
+  })
+
+  it("should log an error if its not an NodeJS.ErrnoException (and the error has a message)", () => {
+    const errorMessage = "handleArgsSocketCatchError Error"
+    const error = new Error(errorMessage)
+
+    handleArgsSocketCatchError(error)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(errorMessage)
+  })
+
+  it("should not log an error if its a iNodeJS.ErrnoException", () => {
+    const error: NodeJS.ErrnoException = new Error()
+    error.code = "ENOENT"
+
+    handleArgsSocketCatchError(error)
+
+    expect(spy).toHaveBeenCalledTimes(0)
+  })
+
+  it("should log an error if the code is not ENOENT (and the error has a message)", () => {
+    const errorMessage = "no access"
+    const error: NodeJS.ErrnoException = new Error()
+    error.code = "EACCESS"
+    error.message = errorMessage
+
+    handleArgsSocketCatchError(error)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(errorMessage)
+  })
+
+  it("should log an error if the code is not ENOENT", () => {
+    const error: NodeJS.ErrnoException = new Error()
+    error.code = "EACCESS"
+
+    handleArgsSocketCatchError(error)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(error)
   })
 })


### PR DESCRIPTION
This PR adds more tests for `src/node/app.ts` to hit 100% coverage for this file.

![image](https://user-images.githubusercontent.com/3806031/133490146-6865e51f-8577-49aa-81a1-0fc05e01e617.png)

Fixes #4094

## Notes

<details>
  <summary>See more</summary>

What is this file? 
`src/node/app.ts`

What does it do? 
It exports two functions: `createApp` and `ensureAddress`

What are these functions used for?
`createApp` creates the main Express app used inside code-server which lets communication happen between the code-server client (in the browser) and the server running code-server on either local or remote machine.

`ensureAddress` ensures that the server has an address and returns it, including the protocol.

What code is untested?

36-40
```ts
if (!resolved) {
  reject(err)
} else {
  // Promise resolved earlier so this is an unrelated error.
  util.logError(logger, "http server error", err)
}
```

45-52
```ts
try {
  await fs.unlink(args.socket)
} catch (error) {
  if (error.code !== "ENOENT") {
    logger.error(error.message)
  }
}
server.listen(args.socket, resolve)
```

### Testing the first block
Let's take a look at 36-40 and understand when this code runs.

This is part of an event listener defined on `server` (which is the `httpolyglot` or `http` server) runs our callback function for the `error` event.

It says, "when the 'error' event is emitted, run this callback."

"This call back is an if/else statement which checks if `resolved` is not true, then reject the outer Promise with the `err` object that came with the 'error' event. Otherwise, the outer Promise resolved earlier so this is an unrelated error. Therefore, use our `util` and call `logError` with our logger and the message 'http server error' along with the `err` object"

The first thing we need to do is set up a test for this. Then we can throw some `console.log`s in there to ensure things are working. After that, we'll need to figure out how to get the server to emit the `error` event.

Woo! I have coverage for 36, 38-40 so far. I need to figure out how to test that `reject` line.

Let's take a look at those this code block as a whole and add comments

```ts
  let resolved = false
  await new Promise<void>(async (resolve2, reject) => {
    const resolve = () => {
      resolved = true
      resolve2()
    }
    server.on("error", (err) => {
      if (!resolved) {
        reject(err) // this line is ONLY called if resolved is false
      } else {
        // Promise resolved earlier so this is an unrelated error.
        util.logError(logger, "http server error", err)
      }
    })

    if (args.socket) {
      try {
        await fs.unlink(args.socket)
      } catch (error) {
        if (error.code !== "ENOENT") {
          logger.error(error.message)
        }
      }
      // resolve is passed here to listen which is used as the listeningListener 
      server.listen(args.socket, resolve)
    } else {
      // [] is the correct format when using :: but Node errors with them.
      // resolve is passed here to listen which is used as the listeningListener
      server.listen(args.port, args.host.replace(/^\[|\]$/g, ""), resolve)
    }
  })
```

From what I can tell, it seems like it's absolutely impossible for that `reject` line to be called unless we close and then listen again on a new port? we can try it.

No no, nevermind...`resolved` never gets reset so even if I close the server and listen again, that value is still `true`. I don't think that line can be hit.

STOPPED HERE 

My thinking is this:

If it can't be hit, I'm thinking of refactoring to remove it.
If it can be hit, I think the only way to get testing coverage is to extract some of that logic into a function so I can test resolved being true and false

Woohoo! We did it.

</details>