### PR TITLE
feat: add test for get_nfpm_arch()

### DIFF
--- a/ci/build/arch-override.json
+++ b/ci/build/arch-override.json
@@ -1,8 +1,0 @@
-{
-  "rpm": {
-    "armv7l": "armhfp"
-  },
-  "deb": {
-    "armv7l": "armhf"
-  }
-}

--- a/ci/build/build-lib.sh
+++ b/ci/build/build-lib.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# This is a library which contains functions used inside ci/build
+#
+# We separated it into it's own file so that we could easily unit test
+# these functions and helpers.
+
+# On some CPU architectures (notably node/uname "armv7l", default on Raspberry Pis),
+# different package managers have different labels for the same CPU (deb=armhf, rpm=armhfp).
+# This function returns the overriden arch on platforms
+# with alternate labels, or the same arch otherwise.
+get_nfpm_arch() {
+  local PKG_FORMAT="${1:-}"
+  local ARCH="${2:-}"
+
+  case "$ARCH" in
+    armv7l)
+      if [ "$PKG_FORMAT" = "deb" ]; then
+        echo armhf
+      elif [ "$PKG_FORMAT" = "rpm" ]; then
+        echo armhfp
+      fi
+      ;;
+    *)
+      echo "$ARCH"
+      ;;
+  esac
+}

--- a/ci/build/build-packages.sh
+++ b/ci/build/build-packages.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 main() {
   cd "$(dirname "${0}")/../.."
   source ./ci/lib.sh
+  source ./ci/build/build-lib.sh
 
   # Allow us to override architecture
   # we use this for our Linux ARM64 cross compile builds
@@ -43,18 +44,6 @@ release_gcp() {
   cp "./release-packages/$release_name.tar.gz" "./release-gcp/latest/$OS-$ARCH.tar.gz"
 }
 
-# On some CPU architectures (notably node/uname "armv7l", default on Raspberry Pis),
-# different package managers have different labels for the same CPU (deb=armhf, rpm=armhfp).
-# This function parses arch-override.json and returns the overriden arch on platforms
-# with alternate labels, or the same arch otherwise.
-get_nfpm_arch() {
-  if jq -re ".${PKG_FORMAT}.${ARCH}" ./ci/build/arch-override.json > /dev/null; then
-    jq -re ".${PKG_FORMAT}.${ARCH}" ./ci/build/arch-override.json
-  else
-    echo "$ARCH"
-  fi
-}
-
 # Generates deb and rpm packages.
 release_nfpm() {
   local nfpm_config
@@ -62,14 +51,14 @@ release_nfpm() {
   export NFPM_ARCH
 
   PKG_FORMAT="deb"
-  NFPM_ARCH="$(get_nfpm_arch)"
+  NFPM_ARCH="$(get_nfpm_arch $PKG_FORMAT "$ARCH")"
   nfpm_config="$(envsubst < ./ci/build/nfpm.yaml)"
   echo "Building deb"
   echo "$nfpm_config" | head --lines=4
   nfpm pkg -f <(echo "$nfpm_config") --target "release-packages/code-server_${VERSION}_${NFPM_ARCH}.deb"
 
   PKG_FORMAT="rpm"
-  NFPM_ARCH="$(get_nfpm_arch)"
+  NFPM_ARCH="$(get_nfpm_arch $PKG_FORMAT "$ARCH")"
   nfpm_config="$(envsubst < ./ci/build/nfpm.yaml)"
   echo "Building rpm"
   echo "$nfpm_config" | head --lines=4

--- a/test/scripts/build-lib.bats
+++ b/test/scripts/build-lib.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+SCRIPT_NAME="build-lib.sh"
+SCRIPT="$BATS_TEST_DIRNAME/../../ci/build/$SCRIPT_NAME"
+
+source "$SCRIPT"
+
+@test "get_nfpm_arch should return armhfp for rpm on armv7l" {
+  run get_nfpm_arch rpm armv7l
+  [ "$output" = "armhfp" ]
+}
+
+@test "get_nfpm_arch should return armhf for deb on armv7l" {
+  run get_nfpm_arch deb armv7l
+  [ "$output" = "armhf" ]
+}
+
+@test "get_nfpm_arch should return arch if no arch override exists " {
+  run get_nfpm_arch deb i386
+  [ "$output" = "i386" ]
+}


### PR DESCRIPTION
This adds tests for build-packages.sh, specifically 

This PR introduces a new file called `build-lib.sh` which extracts the `get_nfpm_arch()` function out of `build-packages.sh` so that it can be unit tested. I did this because if you `source build-packages.sh` it runs the `main` function. 

With this new approach, we can move individual functions related to the build process into `build-lib.sh` and unit test them. 

The inspiration for this came from some recent rockiness with the 3.12.0 release and our interest in stabilizing the build and release pipeline.

![image](https://user-images.githubusercontent.com/3806031/133842205-9ca52575-28ad-495d-bbc3-9bea2ef9a033.png)


Fixes N/A

_Note: I would love if we could fully test all our scripts used in the build and release process. I also tossed around the idea of rewriting these scripts in JS/TS but that's a discussion for the future 😉_