### PR TITLE
feat: add tests for shouldRunVsCodeCli and bindAddrFromArgs

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -626,7 +626,20 @@ function bindAddrFromAllSources(...argsConfig: Args[]): Addr {
 }
 
 export const shouldRunVsCodeCli = (args: Args): boolean => {
-  return !!args["list-extensions"] || !!args["install-extension"] || !!args["uninstall-extension"]
+  // Create new interface with only these keys
+  // Pick<Args, "list-extensions" | "install-extension" | "uninstall-extension">
+  // Get the keys of new interface
+  // keyof ...
+  // Turn that into an array
+  // Array<...>
+  type ExtensionArgs = Array<keyof Pick<Args, "list-extensions" | "install-extension" | "uninstall-extension">>
+  const extensionRelatedArgs: ExtensionArgs = ["list-extensions", "install-extension", "uninstall-extension"]
+
+  const argKeys = Object.keys(args)
+
+  // If any of the extensionRelatedArgs are included in args
+  // then we don't want to run the vscode cli
+  return extensionRelatedArgs.some((arg) => argKeys.includes(arg))
 }
 
 /**

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -594,7 +594,11 @@ interface Addr {
   port: number
 }
 
-function bindAddrFromArgs(addr: Addr, args: Args): Addr {
+/**
+ * This function creates the bind address
+ * using the CLI args.
+ */
+export function bindAddrFromArgs(addr: Addr, args: Args): Addr {
   addr = { ...addr }
   if (args["bind-addr"]) {
     addr = parseBindAddr(args["bind-addr"])
@@ -626,13 +630,11 @@ function bindAddrFromAllSources(...argsConfig: Args[]): Addr {
 }
 
 export const shouldRunVsCodeCli = (args: Args): boolean => {
-  // Create new interface with only these keys
-  // Pick<Args, "list-extensions" | "install-extension" | "uninstall-extension">
-  // Get the keys of new interface
-  // keyof ...
+  // Create new interface with only Arg keys
+  // keyof Args
   // Turn that into an array
   // Array<...>
-  type ExtensionArgs = Array<keyof Pick<Args, "list-extensions" | "install-extension" | "uninstall-extension">>
+  type ExtensionArgs = Array<keyof Args>
   const extensionRelatedArgs: ExtensionArgs = ["list-extensions", "install-extension", "uninstall-extension"]
 
   const argKeys = Object.keys(args)

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -3,7 +3,14 @@ import { promises as fs } from "fs"
 import * as net from "net"
 import * as os from "os"
 import * as path from "path"
-import { Args, parse, setDefaults, shouldOpenInExistingInstance, splitOnFirstEquals } from "../../../src/node/cli"
+import {
+  Args,
+  parse,
+  setDefaults,
+  shouldOpenInExistingInstance,
+  shouldRunVsCodeCli,
+  splitOnFirstEquals,
+} from "../../../src/node/cli"
 import { tmpdir } from "../../../src/node/constants"
 import { paths } from "../../../src/node/util"
 
@@ -461,5 +468,50 @@ describe("splitOnFirstEquals", () => {
     const actual = splitOnFirstEquals(testStr)
     const expected = ["auth"]
     expect(actual).toEqual(expect.arrayContaining(expected))
+  })
+})
+
+describe("shouldRunVsCodeCli", () => {
+  it("should return false if no 'extension' related args passed in", () => {
+    const args = {
+      _: [],
+    }
+    const actual = shouldRunVsCodeCli(args)
+    const expected = false
+
+    expect(actual).toBe(expected)
+  })
+
+  it("should return true if 'list-extensions' passed in", () => {
+    const args = {
+      _: [],
+      ["list-extensions"]: true,
+    }
+    const actual = shouldRunVsCodeCli(args)
+    const expected = true
+
+    expect(actual).toBe(expected)
+  })
+
+  it("should return true if 'install-extension' passed in", () => {
+    const args = {
+      _: [],
+      ["install-extension"]: ["hello.world"],
+    }
+    const actual = shouldRunVsCodeCli(args)
+    const expected = true
+
+    expect(actual).toBe(expected)
+  })
+
+  it("should return true if 'uninstall-extension' passed in", () => {
+    const args = {
+      _: [],
+      ["uninstall-extension"]: ["hello.world"],
+    }
+    const actual = shouldRunVsCodeCli(args)
+    const expected = true
+
+    expect(actual).toBe(expected)
   })
 })


### PR DESCRIPTION
This PR adds more tests for `src/node/cli.ts`. Specifically, these functions: `shouldRunVsCodeCli` and `bindAddrFromArgs`

Fixes #4210

TODOS
- [x] `shouldRunVsCodeCli`
- [x] `bindAddrFromArgs`
- [x] fix broken tests? (it seems one test is broken locally for me, probably a local issue)