### PR TITLE
fix(ci): upgrade runner to ubuntu-18.04

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,10 +244,14 @@ jobs:
   # so we just build with "native"/x86_64 node, then download arm64/armv7l node
   # and then put it in our release. We can't smoke test the cross build this way,
   # but this means we don't need to maintain a self-hosted runner!
+
+  # NOTE@jsjoeio:
+  # We used to use 16.04 until GitHub deprecated it on September 20, 2021
+  # See here: https://github.com/actions/virtual-environments/pull/3862/files
   package-linux-cross:
     name: Linux cross-compile builds
     needs: build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     timeout-minutes: 15
     strategy:
       matrix:


### PR DESCRIPTION
## Summary

This PR upgrades the Ubuntu runner 16.04 -> 18.04 for the `package-linux-cross` job in CI.

## Context

4 days ago, CI was working as expected.

Yesterday, it stopped working. 

After talking to @jawnsy, he shared with me that GitHub's infrastructure discontinued ubuntu-16.04: https://github.com/actions/virtual-environments/pull/3862/files on September 20th 

![image](https://user-images.githubusercontent.com/3806031/134227768-c4d39537-686b-492e-822f-c1703ec1d1cf.png)

Therefore, we have no other choice but to upgrade to 18.04.

Will this break anything? _it shouldn't_ (famous last words)

> Ubuntu 16.04 (Xenial Xerus) had glibc 2.23 and Ubuntu 18.04 (Bionic Beaver) has glibc 2.27, so I believe this may raise our minimum version requirement to 2.27: https://launchpad.net/ubuntu/+source/glibc
> It looks like that version was released in early 2018, so that should be fine: https://sourceware.org/legacy-ml/libc-announce/2018/msg00000.html

— @jawnsy 

Fixes N/A
