### PR TITLE
Revert "fix: run postinstall script explicitly with bash (#4116)"

### DIFF
--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -49,7 +49,7 @@ bundle_code_server() {
   {
     "commit": "$(git rev-parse HEAD)",
     "scripts": {
-      "postinstall": "./postinstall.sh"
+      "postinstall": "sh ./postinstall.sh"
     }
   }
 EOF

--- a/ci/build/build-release.sh
+++ b/ci/build/build-release.sh
@@ -49,7 +49,7 @@ bundle_code_server() {
   {
     "commit": "$(git rev-parse HEAD)",
     "scripts": {
-      "postinstall": "bash ./postinstall.sh"
+      "postinstall": "./postinstall.sh"
     }
   }
 EOF


### PR DESCRIPTION
## Summary 

This reverts commit b32b4edf3d1167f87cb3f4aaf1acd3d5378cefb3.

We are reverting this because we found out that while this fixes the postinstall
on Windows, it breaks it on mac and other devices.  

See: https://github.com/cdr/code-server/issues/3874#issuecomment-925397980

### Additional Context

This change came in #4116 came from @maxloh with the goal of: 

> Currently, Windows default script-shell (cmd) fails to run the postinstall script.
>
> This commit fixes the problem by running postinstall.sh explicitly with the default bash executable of the OS.

While that fixed the postinstall issue on Windows, it broke it for anyone installing with Homebrew since our formula does not depend on `bash`. Instead of modifying the formula, we are opting for reverting b32b4edf3d1167f87cb3f4aaf1acd3d5378cefb3 and using `sh` instead. 

Our reasoning is that if someone on Windows has `bash`, surely they have `sh` as well. 

_Note: we don't know how @maxloh was actually installing code-server so we don't have an exact way to test for their situation but this should work. I had also proposed doing this:_

```json
"scripts": {
      "postinstall": "[ $(command -v bash) >/dev/null ] && bash ./postinstall.sh || ./postinstall.sh"
    }
```
_but that assumes the person has `command` installed Windows which may or may not be the case._

We think we should also try to add some tests for this, which we may do in a follow-up PR.

## Todos
- [x] open up follow-up issue https://github.com/cdr/code-server/issues/4232

Fixes #3874
Fixes #4209 