### PR TITLE
docs(MAINTAINING): update release section + add team section

### DIFF
--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -3,6 +3,7 @@
 # Maintaining
 
 - [Maintaining](#maintaining)
+  - [Team](#team)
   - [Workflow](#workflow)
     - [Milestones](#milestones)
     - [Triage](#triage)
@@ -18,14 +19,18 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+This document is meant to serve current and future maintainers of code-server,
+as well as share our workflow for maintaining the project.
+
+## Team
+
 Current maintainers:
 
 - @code-asher
 - @TeffenEllis
 - @jsjoeio
 
-This document is meant to serve current and future maintainers of code-server,
-as well as share our workflow for maintaining the project.
+Occassionally, other Coder employees may step in time to time to assist with code-server.
 
 ## Workflow
 

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,24 +1,26 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
 # Maintaining
 
-- [Maintaining](#maintaining)
-  - [Team](#team)
-    - [Onboarding](#onboarding)
-    - [Offboarding](#offboarding)
-  - [Workflow](#workflow)
-    - [Milestones](#milestones)
-    - [Triage](#triage)
-    - [Project boards](#project-boards)
-  - [Versioning](#versioning)
-  - [Pull requests](#pull-requests)
-    - [Merge strategies](#merge-strategies)
-    - [Changelog](#changelog)
-  - [Releases](#releases)
-    - [Publishing a release](#publishing-a-release)
-  - [Documentation](#documentation)
-    - [Troubleshooting](#troubleshooting)
+- [Team](#team)
+  - [Onboarding](#onboarding)
+  - [Offboarding](#offboarding)
+- [Workflow](#workflow)
+  - [Milestones](#milestones)
+  - [Triage](#triage)
+  - [Project boards](#project-boards)
+- [Versioning](#versioning)
+- [Pull requests](#pull-requests)
+  - [Merge strategies](#merge-strategies)
+  - [Changelog](#changelog)
+- [Releases](#releases)
+  - [Publishing a release](#publishing-a-release)
+    - [AUR](#aur)
+    - [Docker](#docker)
+    - [Homebrew](#homebrew)
+    - [npm](#npm)
+- [Documentation](#documentation)
+  - [Troubleshooting](#troubleshooting)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -183,6 +185,33 @@ If you're the current release manager, follow these steps:
 1. Update the AUR package. Instructions for updating the AUR package are at
    [cdr/code-server-aur](https://github.com/cdr/code-server-aur).
 1. Wait for the npm package to be published.
+
+#### AUR
+
+We publish to AUR as a package [here](https://aur.archlinux.org/packages/code-server/). This process is manual and can be done by following the steps in [this repo](https://github.com/cdr/code-server-aur).
+
+#### Docker
+
+We publish code-server as a Docker image [here](https://registry.hub.docker.com/r/codercom/code-server), tagging it both with the version and latest.
+
+This is currently automated with the release process.
+
+#### Homebrew
+
+We publish code-server on Homebrew [here](https://github.com/Homebrew/homebrew-core/blob/master/Formula/code-server.rb).
+
+This is currently automated with the release process (but may fail occassionally). If it does, run this locally:
+
+```shell
+# Replace VERSION with version
+brew bump-formula-pr --version="${VERSION}" code-server --no-browse --no-audit
+```
+
+#### npm
+
+We publish code-server as an npm package [here](https://www.npmjs.com/package/code-server/v/latest).
+
+This is currently automated with the release process.
 
 ## Documentation
 

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -51,7 +51,7 @@ To onboard a new maintainer to the project, please make sure to do the following
 
 Very similar to Onboarding but Remove maintainer from all teams and revoke access. Please also do the following:
 
-- [ ] Write fairwell post via Discussion (see [example](https://github.com/cdr/code-server/discussions/3933))
+- [ ] Write farewell post via Discussion (see [example](https://github.com/cdr/code-server/discussions/3933))
 
 ## Workflow
 
@@ -164,6 +164,7 @@ If you're the current release manager, follow these steps:
 
 ### Publishing a release
 
+1. Create a release branch called `v0.0.0` but replace with new version
 1. Run `yarn release:prep` and type in the new version (e.g., `3.8.1`)
 1. GitHub Actions will generate the `npm-package`, `release-packages` and
    `release-images` artifacts. You do not have to wait for this step to complete
@@ -209,7 +210,7 @@ brew bump-formula-pr --version="${VERSION}" code-server --no-browse --no-audit
 
 #### npm
 
-We publish code-server as an npm package [here](https://www.npmjs.com/package/code-server/v/latest).
+We publish code-server as a npm package [here](https://www.npmjs.com/package/code-server/v/latest).
 
 This is currently automated with the release process.
 

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -2,18 +2,19 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 # Maintaining
 
-- [Workflow](#workflow)
-  - [Milestones](#milestones)
-  - [Triage](#triage)
-  - [Project boards](#project-boards)
-- [Versioning](#versioning)
-- [Pull requests](#pull-requests)
-  - [Merge strategies](#merge-strategies)
-  - [Changelog](#changelog)
-- [Releases](#releases)
-  - [Publishing a release](#publishing-a-release)
-- [Documentation](#documentation)
-  - [Troubleshooting](#troubleshooting)
+- [Maintaining](#maintaining)
+  - [Workflow](#workflow)
+    - [Milestones](#milestones)
+    - [Triage](#triage)
+    - [Project boards](#project-boards)
+  - [Versioning](#versioning)
+  - [Pull requests](#pull-requests)
+    - [Merge strategies](#merge-strategies)
+    - [Changelog](#changelog)
+  - [Releases](#releases)
+    - [Publishing a release](#publishing-a-release)
+  - [Documentation](#documentation)
+    - [Troubleshooting](#troubleshooting)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -21,7 +22,6 @@ Current maintainers:
 
 - @code-asher
 - @TeffenEllis
-- @oxy
 - @jsjoeio
 
 This document is meant to serve current and future maintainers of code-server,

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -1,9 +1,12 @@
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 # Maintaining
 
 - [Maintaining](#maintaining)
   - [Team](#team)
+    - [Onboarding](#onboarding)
+    - [Offboarding](#offboarding)
   - [Workflow](#workflow)
     - [Milestones](#milestones)
     - [Triage](#triage)
@@ -31,6 +34,22 @@ Current maintainers:
 - @jsjoeio
 
 Occassionally, other Coder employees may step in time to time to assist with code-server.
+
+### Onboarding
+
+To onboard a new maintainer to the project, please make sure to do the following:
+
+- [ ] Add to [cdr/code-server-reviewers](https://github.com/orgs/cdr/teams/code-server-reviewers)
+- [ ] Add as Admin under [Repository Settings > Access](https://github.com/cdr/code-server/settings/access)
+- [ ] Add to [npm Coder org](https://www.npmjs.com/org/coder)
+- [ ] Add as [AUR maintainer](https://aur.archlinux.org/packages/code-server/) (talk to Colin)
+- [ ] Introduce to community via Discussion (see [example](https://github.com/cdr/code-server/discussions/3955))
+
+### Offboarding
+
+Very similar to Onboarding but Remove maintainer from all teams and revoke access. Please also do the following:
+
+- [ ] Write fairwell post via Discussion (see [example](https://github.com/cdr/code-server/discussions/3933))
 
 ## Workflow
 


### PR DESCRIPTION
This PR updates the `MAINTAINING` docs, specifically:
- adds Team section with Onboarding and Offboardng sections
- adds notes around release platforms
- updates release instructions with step for naming version branch correctly

Fixes #3894
Fixes #4174
