### PR TITLE
fix(brew-bump.sh): add checks and handle errors 

### DIFF
--- a/ci/steps/brew-bump.sh
+++ b/ci/steps/brew-bump.sh
@@ -5,6 +5,21 @@ main() {
   cd "$(dirname "$0")/../.."
   # Only sourcing this so we get access to $VERSION
   source ./ci/lib.sh
+  source ./ci/steps/steps-lib.sh
+
+  echo "Checking environment variables"
+
+  # We need VERSION to bump the brew formula
+  if [[ $(is_env_var_set "VERSION") -eq 1 ]]; then
+    echo "VERSION is not set"
+    exit 1
+  fi
+
+  # We need HOMEBREW_GITHUB_API_TOKEN to push up commits
+  if [[ $(is_env_var_set "HOMEBREW_GITHUB_API_TOKEN") -eq 1 ]]; then
+    echo "HOMEBREW_GITHUB_API_TOKEN is not set"
+    exit 1
+  fi
 
   # NOTE: we need to make sure cdrci/homebrew-core
   # is up-to-date
@@ -13,27 +28,62 @@ main() {
   echo "Cloning cdrci/homebrew-core"
   git clone https://github.com/cdrci/homebrew-core.git
 
+  # Make sure the git clone step is successful
+  if [[ $(directory_exists "homebrew-core") -eq 1 ]]; then
+    echo "git clone failed. Cannot find homebrew-core directory."
+    ls -la
+    exit 1
+  fi
+
   echo "Changing into homebrew-core directory"
   cd homebrew-core && pwd
 
-  echo "Adding Homebrew/homebrew-core as $(upstream)"
+  echo "Adding Homebrew/homebrew-core"
   git remote add upstream https://github.com/Homebrew/homebrew-core.git
 
+  # Make sure the git remote step is successful
+  if ! git config remote.upstream.url > /dev/null; then
+    echo "git remote add upstream failed."
+    echo "Could not find upstream in list of remotes."
+    git remote -v
+    exit 1
+  fi
+
+  # TODO@jsjoeio - can I somehow check that this succeeded?
   echo "Fetching upstream Homebrew/hombrew-core commits"
   git fetch upstream
 
+  # TODO@jsjoeio - can I somehow check that this succeeded?
   echo "Merging in latest Homebrew/homebrew-core changes"
   git merge upstream/master
 
   echo "Pushing changes to cdrci/homebrew-core fork on GitHub"
-  # Source: https://serverfault.com/a/912788
-  # shellcheck disable=SC2016,SC2028
-  echo '#!/bin/sh\nexec echo "$HOMEBREW_GITHUB_API_TOKEN"' > "$HOME"/.git-askpass.sh
-  # Ensure it's executable since we just created it
-  chmod +x "$HOME/.git-askpass.sh"
+
   # GIT_ASKPASS lets us use the password when pushing without revealing it in the process list
   # See: https://serverfault.com/a/912788
-  GIT_ASKPASS="$HOME/.git-askpass.sh" git push https://cdr-oss@github.com/cdr-oss/homebrew-core.git --all
+  GIT_ASKPASS="$HOME/git-askpass.sh"
+  # Source: https://serverfault.com/a/912788
+  # shellcheck disable=SC2016,SC2028
+  echo '#!/bin/sh\nexec echo "$HOMEBREW_GITHUB_API_TOKEN"' > "$GIT_ASKPASS"
+
+  # Make sure the git-askpass.sh file creation is successful
+  if [[ $(file_exists "git-askpass.sh") -eq 1 ]]; then
+    echo "git-askpass.sh not found in $HOME."
+    ls -la "$HOME"
+    exit 1
+  fi
+
+  # Ensure it's executable since we just created it
+  chmod +x "$GIT_ASKPASS"
+
+  # Make sure the git-askpass.sh file is executable
+  if [[ $(is_executable "$GIT_ASKPASS") -eq 1 ]]; then
+    echo "git-askpass.sh is not executable."
+    ls -la "$GIT_ASKPASS"
+    exit 1
+  fi
+
+  git push https://cdr-oss@github.com/cdr-oss/homebrew-core.git --all
 
   # Find the docs for bump-formula-pr here
   # https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/bump-formula-pr.rb#L18
@@ -50,6 +100,8 @@ main() {
   # Clean up and remove homebrew-core
   cd ..
   rm -rf homebrew-core
+
+  # TODO@jsjoeio - check that homebrew-core was removed
 }
 
 main "$@"

--- a/ci/steps/steps-lib.sh
+++ b/ci/steps/steps-lib.sh
@@ -10,9 +10,9 @@
 is_env_var_set() {
   local name="${1:-}"
   if test -n "${!name:-}"; then
-    echo 0
+    return 0
   else
-    echo 1
+    return 1
   fi
 }
 
@@ -20,9 +20,9 @@ is_env_var_set() {
 directory_exists() {
   local dir="${1:-}"
   if [[ -d "${dir:-}" ]]; then
-    echo 0
+    return 0
   else
-    echo 1
+    return 1
   fi
 }
 
@@ -30,9 +30,9 @@ directory_exists() {
 file_exists() {
   local file="${1:-}"
   if test -f "${file:-}"; then
-    echo 0
+    return 0
   else
-    echo 1
+    return 1
   fi
 }
 
@@ -40,8 +40,8 @@ file_exists() {
 is_executable() {
   local file="${1:-}"
   if [ -f "${file}" ] && [ -r "${file}" ] && [ -x "${file}" ]; then
-    echo 0
+    return 0
   else
-    echo 1
+    return 1
   fi
 }

--- a/ci/steps/steps-lib.sh
+++ b/ci/steps/steps-lib.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# This is a library which contains functions used inside ci/steps
+#
+# We separated it into it's own file so that we could easily unit test
+# these functions and helpers
+
+# Checks whether and environment variable is set.
+# Source: https://stackoverflow.com/a/62210688/3015595
+is_env_var_set() {
+  local name="${1:-}"
+  if test -n "${!name:-}"; then
+    echo 0
+  else
+    echo 1
+  fi
+}
+
+# Checks whether a directory exists.
+directory_exists() {
+  local dir="${1:-}"
+  if [[ -d "${dir:-}" ]]; then
+    echo 0
+  else
+    echo 1
+  fi
+}
+
+# Checks whether a file exists.
+file_exists() {
+  local file="${1:-}"
+  if test -f "${file:-}"; then
+    echo 0
+  else
+    echo 1
+  fi
+}
+
+# Checks whether a file is executable.
+is_executable() {
+  local file="${1:-}"
+  if [ -f "${file}" ] && [ -r "${file}" ] && [ -x "${file}" ]; then
+    echo 0
+  else
+    echo 1
+  fi
+}

--- a/test/scripts/steps-lib.bats
+++ b/test/scripts/steps-lib.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+SCRIPT_NAME="steps-lib.sh"
+SCRIPT="$BATS_TEST_DIRNAME/../../ci/steps/$SCRIPT_NAME"
+
+source "$SCRIPT"
+
+@test "is_env_var_set should return 1 if env var is not set" {
+  run is_env_var_set "ASDF_TEST_SET"
+  [ "$output" = 1 ]
+}
+
+@test "is_env_var_set should return 0 if env var is set" {
+  ASDF_TEST_SET="test" run is_env_var_set "ASDF_TEST_SET"
+  [ "$output" = 0 ]
+}
+
+@test "directory_exists should 1 if directory doesn't exist" {
+  run directory_exists "/tmp/asdfasdfasdf"
+  [ "$output" = 1 ]
+}
+
+@test "directory_exists should 0 if directory exists" {
+  run directory_exists "$(pwd)"
+  [ "$output" = 0 ]
+}
+
+@test "file_exists should 1 if file doesn't exist" {
+  run file_exists "hello-asfd.sh"
+  [ "$output" = 1 ]
+}
+
+@test "file_exists should 0 if file exists" {
+  run file_exists "$SCRIPT"
+  [ "$output" = 0 ]
+}
+
+@test "is_executable should 1 if file isn't executable" {
+  run is_executable "hello-asfd.sh"
+  [ "$output" = 1 ]
+}
+
+@test "is_executable should 0 if file is executable" {
+  run is_executable "$SCRIPT"
+  [ "$output" = 0 ]
+}

--- a/test/scripts/steps-lib.bats
+++ b/test/scripts/steps-lib.bats
@@ -7,40 +7,40 @@ source "$SCRIPT"
 
 @test "is_env_var_set should return 1 if env var is not set" {
   run is_env_var_set "ASDF_TEST_SET"
-  [ "$output" = 1 ]
+  [ "$status" = 1 ]
 }
 
 @test "is_env_var_set should return 0 if env var is set" {
   ASDF_TEST_SET="test" run is_env_var_set "ASDF_TEST_SET"
-  [ "$output" = 0 ]
+  [ "$status" = 0 ]
 }
 
 @test "directory_exists should 1 if directory doesn't exist" {
   run directory_exists "/tmp/asdfasdfasdf"
-  [ "$output" = 1 ]
+  [ "$status" = 1 ]
 }
 
 @test "directory_exists should 0 if directory exists" {
   run directory_exists "$(pwd)"
-  [ "$output" = 0 ]
+  [ "$status" = 0 ]
 }
 
 @test "file_exists should 1 if file doesn't exist" {
   run file_exists "hello-asfd.sh"
-  [ "$output" = 1 ]
+  [ "$status" = 1 ]
 }
 
 @test "file_exists should 0 if file exists" {
   run file_exists "$SCRIPT"
-  [ "$output" = 0 ]
+  [ "$status" = 0 ]
 }
 
 @test "is_executable should 1 if file isn't executable" {
   run is_executable "hello-asfd.sh"
-  [ "$output" = 1 ]
+  [ "$status" = 1 ]
 }
 
 @test "is_executable should 0 if file is executable" {
   run is_executable "$SCRIPT"
-  [ "$output" = 0 ]
+  [ "$status" = 0 ]
 }


### PR DESCRIPTION
This PR adds a lot of bash helper functions (+ tests) used in `brew-bump.sh` in order to ensure this script doesn't fail when publishing a release.

![image](https://user-images.githubusercontent.com/3806031/134998218-0ee44b6a-d909-4067-b016-5e8ad8fdda77.png)

## TODOs

- [x] add BATS test for `steps-lib.sh`
- [x] add check + test for `$VERSION`
- [x] add check for `cdr/ci/homebrew`
- [x] add check for remote upstream
- [x] add check for `$HOMEBREW_GITHUB_API_TOKEN` 
- [x] add check for `git-ask-pass.sh`
- [x] add check for cleaning up homebrew-core
- [x] fix Trivy vulnerability (https://github.com/cdr/code-server/pull/4251)
- [x] test the `GIT_ASKPASS` in isolated environment

Fixes #3962

## Test Plan

To test out the other parts of the script (specifically `GIT_ASKPASS`), here is what I did:
1. Create new Workspace on `https://master.cdr.dev/workspaces`
2. "log out" of git with:
```shell
git config --global --unset user.name
git config --global --unset user.email
git config --global --unset credential.helper
```
3.  Verify log out by trying to clone via HTTPS a private repo:
```shell
git clone https://github.com/jsjoeio/dip.chat-v2.git
```
4. Create script similar to `brew-bump.sh` and add `steps-lib.sh` to Workspace.
5. Make script executable `chmod +x test-brew.sh`
6. Run script: `VERSION="1.2.3" HOMEBREW_GITHUB_API_TOKEN="<redcated>" ./test-brew.sh` (make sure the token had `repo` and `workflow` in scope).

## Notes

Ran into issues with scripts that used `set -u` so that's why I created a new file called `steps-lib.sh`.

See: https://github.com/sstephenson/bats/issues/171