### PR TITLE
Use Ingress v1 from Kubernetes v1.19 in helm chart

### DIFF
--- a/ci/helm-chart/templates/ingress.yaml
+++ b/ci/helm-chart/templates/ingress.yaml
@@ -1,7 +1,9 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "code-server.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -27,6 +29,22 @@ spec:
     {{- end }}
   {{- end }}
   rules:
+  {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion -}}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port: 
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+  {{- else -}}
     {{- range .Values.ingress.hosts }}
     - host: {{ .host | quote }}
       http:
@@ -39,3 +57,4 @@ spec:
           {{- end }}
     {{- end }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
Hi. I found you use old version of Ingress in helm chart.
Ingress became GA in [Kubernetes v1.19](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.19.md#ingress-graduates-to-general-availability).

Output after v1.19
```
# Source: code-server/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: code-server
  labels:
    helm.sh/chart: code-server-1.0.3
    app.kubernetes.io/name: code-server
    app.kubernetes.io/instance: code-server
    app.kubernetes.io/version: "3.12.0"
    app.kubernetes.io/managed-by: Helm
spec:
  rules:
    - host: "code-server.example.loc"
      http:
        paths:
          - path: /
            backend:
              service:
                name: code-server
                port: 
                  number: 8080
```