### PR TITLE
fix: update CODEOWNERS for helm-chart

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @cdr/code-server-reviewers
 
-ci/helm-chart @Matthew-Beckett @alexgorbatchev
+ci/helm-chart/ @Matthew-Beckett @alexgorbatchev


### PR DESCRIPTION
This PR makes a minor update to `CODEOWNERS`.

Fixes https://github.com/cdr/code-server/pull/4244#issuecomment-928243088
