### PR TITLE
chore(helm-chart): bump to 1.0.5

### DIFF
--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.4
+version: 1.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/ci/helm-chart/Chart.yaml
+++ b/ci/helm-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.3
+version: 1.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
This PR bumps the helm-chart version 1.0.3 -> 1.0.5 to account for two patches/changes we made since we last bumped it:
- https://github.com/cdr/code-server/commit/5a36627aae7d8772f4190453dc8aae5da7e73104
- https://github.com/cdr/code-server/commit/1ffca5751c36235af686d13c788c8ace5bb0a117

Fixes #3794

cc @Matthew-Beckett @alexgorbatchev