### PR TITLE
feat(cli): add test for readSocketPath

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -4,7 +4,7 @@ import yaml from "js-yaml"
 import * as os from "os"
 import * as path from "path"
 import { Args as VsArgs } from "../../typings/ipc"
-import { canConnect, generateCertificate, generatePassword, humanPath, paths } from "./util"
+import { canConnect, generateCertificate, generatePassword, humanPath, isNodeJSErrnoException, paths } from "./util"
 
 export enum Feature {
   /** Web socket compression. */
@@ -666,7 +666,7 @@ export async function readSocketPath(): Promise<string | undefined> {
   try {
     return await fs.readFile(path.join(os.tmpdir(), "vscode-ipc"), "utf8")
   } catch (error) {
-    if (error.code !== "ENOENT") {
+    if (!isNodeJSErrnoException(error) || error.code !== "ENOENT") {
       throw error
     }
   }

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -667,6 +667,7 @@ export const shouldOpenInExistingInstance = async (args: Args): Promise<string |
     return process.env.VSCODE_IPC_HOOK_CLI
   }
 
+  // TODO@jsjoeio - add test here
   const readSocketPath = async (): Promise<string | undefined> => {
     try {
       return await fs.readFile(path.join(os.tmpdir(), "vscode-ipc"), "utf8")

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -656,6 +656,12 @@ export const shouldRunVsCodeCli = (args: Args): boolean => {
   return extensionRelatedArgs.some((arg) => argKeys.includes(arg))
 }
 
+/**
+ * Reads the socketPath which defaults to a temporary directory
+ * with another directory called vscode-ipc.
+ *
+ * If it can't read the path, it throws an error and returns undefined.
+ */
 export async function readSocketPath(): Promise<string | undefined> {
   try {
     return await fs.readFile(path.join(os.tmpdir(), "vscode-ipc"), "utf8")

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -656,6 +656,16 @@ export const shouldRunVsCodeCli = (args: Args): boolean => {
   return extensionRelatedArgs.some((arg) => argKeys.includes(arg))
 }
 
+export async function readSocketPath(): Promise<string | undefined> {
+  try {
+    return await fs.readFile(path.join(os.tmpdir(), "vscode-ipc"), "utf8")
+  } catch (error) {
+    if (error.code !== "ENOENT") {
+      throw error
+    }
+  }
+  return undefined
+}
 /**
  * Determine if it looks like the user is trying to open a file or folder in an
  * existing instance. The arguments here should be the arguments the user
@@ -665,18 +675,6 @@ export const shouldOpenInExistingInstance = async (args: Args): Promise<string |
   // Always use the existing instance if we're running from VS Code's terminal.
   if (process.env.VSCODE_IPC_HOOK_CLI) {
     return process.env.VSCODE_IPC_HOOK_CLI
-  }
-
-  // TODO@jsjoeio - add test here
-  const readSocketPath = async (): Promise<string | undefined> => {
-    try {
-      return await fs.readFile(path.join(os.tmpdir(), "vscode-ipc"), "utf8")
-    } catch (error) {
-      if (error.code !== "ENOENT") {
-        throw error
-      }
-    }
-    return undefined
   }
 
   // If these flags are set then assume the user is trying to open in an

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -663,6 +663,8 @@ export const shouldRunVsCodeCli = (args: Args): boolean => {
  * If it can't read the path, it throws an error and returns undefined.
  */
 export async function readSocketPath(): Promise<string | undefined> {
+  // TODO@jsjoeio - we should make this function pure and pass in the path
+  // to the file it reads
   try {
     return await fs.readFile(path.join(os.tmpdir(), "vscode-ipc"), "utf8")
   } catch (error) {

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -531,5 +531,5 @@ export function escapeHtml(unsafe: string): string {
  * it has a .code property.
  */
 export function isNodeJSErrnoException(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && (error as NodeJS.ErrnoException).code !== undefined
+  return error !== undefined && (error as NodeJS.ErrnoException).code !== undefined
 }

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -8,6 +8,7 @@ import {
   bindAddrFromArgs,
   defaultConfigFile,
   parse,
+  readSocketPath,
   setDefaults,
   shouldOpenInExistingInstance,
   shouldRunVsCodeCli,
@@ -653,5 +654,35 @@ describe("defaultConfigFile", () => {
 auth: password
 password: ${password}
 cert: false`)
+  })
+})
+
+describe.only("readSocketPath", () => {
+  const vscodeIpcPath = path.join(os.tmpdir(), "vscode-ipc")
+  const fileContents = "readSocketPath file contents"
+
+  beforeEach(async () => {
+    await fs.writeFile(vscodeIpcPath, fileContents)
+  })
+
+  afterEach(async () => {
+    await fs.rmdir(vscodeIpcPath, { recursive: true })
+  })
+
+  it.skip("should throw an error if it can't read the file", async () => {
+    // TODO@jsjoeio - implement
+    // TODO@jsjoeio - implement
+    const p = await readSocketPath()
+    console.log(p)
+    expect(p).toThrowError("oops")
+  })
+  it.skip("should return undefined if it can't read the file", async () => {
+    // TODO@jsjoeio - implement
+    const socketPath = await readSocketPath()
+    expect(socketPath).toBeUndefined()
+  })
+  it("should return the file contents", async () => {
+    const contents = await readSocketPath()
+    expect(contents).toBe(fileContents)
   })
 })


### PR DESCRIPTION
This PR adds tests for `readSocketPath`.

## TODOs

- [x] extract `readSocketPath` and export
- [x] fix TS error
- [ ] write test for `readSocketPath`

Fixes N/A
