### PR TITLE
feat(cli): add test for readSocketPath

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,14 +31,18 @@ jobs:
       - name: Install helm
         uses: azure/setup-helm@v1.1
 
-      - name: Fetch dependencies from cache
-        id: cache-yarn
-        uses: actions/cache@v2
-        with:
-          path: "**/node_modules"
-          key: yarn-build-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-build-
+      # NOTE@jsjoeio
+      # disabling this until we can audit the build process
+      # and the usefulness of this step
+      # See: https://github.com/cdr/code-server/issues/4287
+      # - name: Fetch dependencies from cache
+      #   id: cache-yarn
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: "**/node_modules"
+      #     key: yarn-build-${{ hashFiles('**/yarn.lock') }}
+      #     restore-keys: |
+      #       yarn-build-
 
       - name: Install dependencies
         # if: steps.cache-yarn.outputs.cache-hit != 'true'

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -662,7 +662,7 @@ function bindAddrFromAllSources(...argsConfig: Args[]): Addr {
 /**
  * Reads the socketPath based on path passed in.
  *
- * The one usually pased in is the DEFAULT_SOCKET_PATH.
+ * The one usually passed in is the DEFAULT_SOCKET_PATH.
  *
  * If it can't read the path, it throws an error and returns undefined.
  */

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -660,8 +660,9 @@ function bindAddrFromAllSources(...argsConfig: Args[]): Addr {
 }
 
 /**
- * Reads the socketPath which defaults to a temporary directory
- * with another directory called vscode-ipc.
+ * Reads the socketPath based on path passed in.
+ *
+ * The one usually pased in is the DEFAULT_SOCKET_PATH.
  *
  * If it can't read the path, it throws an error and returns undefined.
  */

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -490,7 +490,7 @@ export function escapeHtml(unsafe: string): string {
  * it has a .code property.
  */
 export function isNodeJSErrnoException(error: unknown): error is NodeJS.ErrnoException {
-  return error instanceof Error && (error as NodeJS.ErrnoException).code !== undefined
+  return error !== undefined && (error as NodeJS.ErrnoException).code !== undefined
 }
 
 // TODO: Replace with proper templating system.

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -11,11 +11,11 @@ import {
   setDefaults,
   shouldOpenInExistingInstance,
   splitOnFirstEquals,
+  readSocketPath,
 } from "../../../src/node/cli"
-import { tmpdir } from "../../../src/node/constants"
 import { shouldSpawnCliProcess } from "../../../src/node/main"
 import { generatePassword, paths } from "../../../src/node/util"
-import { useEnv } from "../../utils/helpers"
+import { useEnv, tmpdir } from "../../utils/helpers"
 
 type Mutable<T> = {
   -readonly [P in keyof T]: T[P]
@@ -390,10 +390,11 @@ describe("parser", () => {
 
 describe("cli", () => {
   let args: Mutable<Args> = { _: [] }
-  const testDir = path.join(tmpdir, "tests/cli")
+  let testDir: string
   const vscodeIpcPath = path.join(os.tmpdir(), "vscode-ipc")
 
   beforeAll(async () => {
+    testDir = await tmpdir("cli")
     await fs.rmdir(testDir, { recursive: true })
     await fs.mkdir(testDir, { recursive: true })
   })
@@ -665,5 +666,42 @@ describe("defaultConfigFile", () => {
 auth: password
 password: ${password}
 cert: false`)
+  })
+})
+
+describe("readSocketPath", () => {
+  const fileContents = "readSocketPath file contents"
+  let tmpDirPath: string
+  let tmpFilePath: string
+
+  beforeEach(async () => {
+    tmpDirPath = await tmpdir("readSocketPath")
+    tmpFilePath = path.join(tmpDirPath, "readSocketPath.txt")
+    await fs.writeFile(tmpFilePath, fileContents)
+  })
+
+  afterEach(async () => {
+    await fs.rmdir(tmpDirPath, { recursive: true })
+  })
+
+  it("should throw an error if it can't read the file", async () => {
+    // TODO@jsjoeio - implement
+    // Test it on a directory.... ESDIR
+    // TODO@jsjoeio - implement
+    expect(() => readSocketPath(tmpDirPath)).rejects.toThrow("EISDIR")
+  })
+  it("should return undefined if it can't read the file", async () => {
+    // TODO@jsjoeio - implement
+    const socketPath = await readSocketPath(path.join(tmpDirPath, "not-a-file"))
+    expect(socketPath).toBeUndefined()
+  })
+  it("should return the file contents", async () => {
+    const contents = await readSocketPath(tmpFilePath)
+    expect(contents).toBe(fileContents)
+  })
+  it("should return the same file contents for two different calls", async () => {
+    const contents1 = await readSocketPath(tmpFilePath)
+    const contents2 = await readSocketPath(tmpFilePath)
+    expect(contents2).toBe(contents1)
   })
 })


### PR DESCRIPTION
This PR adds tests for `readSocketPath`.

## TODOs

- [x] extract `readSocketPath` and export
- [x] fix TS error
- [x] write test for `readSocketPath`

Fixes N/A
