### PR TITLE
refactor(ci): only run release workflows on released event

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   docker-images:

--- a/.github/workflows/npm-brew.yaml
+++ b/.github/workflows/npm-brew.yaml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
   release:
-    types: [published]
+    types: [released]
 
 jobs:
   # NOTE: this job requires curl, jq and yarn


### PR DESCRIPTION
This PR updates the trigger event for both the "Publish on npm and brew" and the "Publish on Docker" release workflows so that they only run on `released` (instead of `published`).

## Why is this change necessary?

In order for us to publish pre-releases _without_ triggering these workflows, this change needs to happen.

We learned this through the [GitHub Actions docs](https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#release):

> Note: The prereleased type will not trigger for pre-releases published from draft releases, but the published type will trigger. If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased.

 

Fixes N/A
Related https://github.com/cdr/code-server/issues/4264
