### PR TITLE
Fix: use pipe to spawn http server process to enable logs pipe to files

### DIFF
--- a/src/node/wrapper.ts
+++ b/src/node/wrapper.ts
@@ -314,7 +314,7 @@ export class ParentProcess extends Process {
         CODE_SERVER_PARENT_PID: process.pid.toString(),
         NODE_OPTIONS: `--max-old-space-size=2048 ${process.env.NODE_OPTIONS || ""}`,
       },
-      stdio: ["inherit", "inherit", "inherit", "ipc"],
+      stdio: ["pipe", "pipe", "pipe", "ipc"],
     })
   }
 


### PR DESCRIPTION
Previously we use `inherit` in stdio param to spawn the http server process(or the child process), which will swallow the logs in child process and not be written to the `code-server-stdout.log`. Using `pipe` will fix this problem.

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
