### PR TITLE
feat(cli): add tests for password, hashed-password

### DIFF
--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -310,12 +310,10 @@ export const parse = (
         throw error(`Unknown option ${arg}`)
       }
 
-      // TODO@jsjoeio add test for this if block
       if (key === "password" && !opts?.configFile) {
         throw new Error("--password can only be set in the config file or passed in via $PASSWORD")
       }
 
-      // TODO@jsjoeio add test for this if block
       if (key === "hashed-password" && !opts?.configFile) {
         throw new Error("--hashed-password can only be set in the config file or passed in via $HASHED_PASSWORD")
       }

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -310,10 +310,12 @@ export const parse = (
         throw error(`Unknown option ${arg}`)
       }
 
+      // TODO@jsjoeio add test for this if block
       if (key === "password" && !opts?.configFile) {
         throw new Error("--password can only be set in the config file or passed in via $PASSWORD")
       }
 
+      // TODO@jsjoeio add test for this if block
       if (key === "hashed-password" && !opts?.configFile) {
         throw new Error("--hashed-password can only be set in the config file or passed in via $HASHED_PASSWORD")
       }

--- a/test/unit/node/cli.test.ts
+++ b/test/unit/node/cli.test.ts
@@ -333,6 +333,18 @@ describe("parser", () => {
     })
   })
 
+  it("should error if password passed in", () => {
+    expect(() => parse(["--password", "supersecret123"])).toThrowError(
+      "--password can only be set in the config file or passed in via $PASSWORD",
+    )
+  })
+
+  it("should error if hashed-password passed in", () => {
+    expect(() => parse(["--hashed-password", "fdas423fs8a"])).toThrowError(
+      "--hashed-password can only be set in the config file or passed in via $HASHED_PASSWORD",
+    )
+  })
+
   it("should filter proxy domains", async () => {
     const args = parse(["--proxy-domain", "*.coder.com", "--proxy-domain", "coder.com", "--proxy-domain", "coder.org"])
     expect(args).toEqual({


### PR DESCRIPTION
This PR adds tests for `code-server/src/node/cli.ts` to cover lines 314,318.

Fixes N/A

#TestingMondays
