### PR TITLE
nginx config minor bug fixed

### DIFF
--- a/docs/guide.md
+++ b/docs/guide.md
@@ -198,7 +198,15 @@ At this point, you should be able to access code-server via
        listen [::]:80;
        server_name mydomain.com;
 
-       location ^~ / {
+       location / {
+         proxy_pass http://localhost:8080/;
+         proxy_set_header Host $host;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection upgrade;
+         proxy_set_header Accept-Encoding gzip;
+       }
+       
+       location /static {
          proxy_pass http://localhost:8080/;
          proxy_set_header Host $host;
          proxy_set_header Upgrade $http_upgrade;
@@ -575,7 +583,15 @@ At this point, you should be able to access code-server via
        listen [::]:80;
        server_name mydomain.com;
 
-       location ^~ / {
+       location / {
+         proxy_pass http://localhost:8080/;
+         proxy_set_header Host $host;
+         proxy_set_header Upgrade $http_upgrade;
+         proxy_set_header Connection upgrade;
+         proxy_set_header Accept-Encoding gzip;
+       }
+       
+       location /static {
          proxy_pass http://localhost:8080/;
          proxy_set_header Host $host;
          proxy_set_header Upgrade $http_upgrade;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -198,15 +198,7 @@ At this point, you should be able to access code-server via
        listen [::]:80;
        server_name mydomain.com;
 
-       location / {
-         proxy_pass http://localhost:8080/;
-         proxy_set_header Host $host;
-         proxy_set_header Upgrade $http_upgrade;
-         proxy_set_header Connection upgrade;
-         proxy_set_header Accept-Encoding gzip;
-       }
-       
-       location /static {
+       location ^~ / {
          proxy_pass http://localhost:8080/;
          proxy_set_header Host $host;
          proxy_set_header Upgrade $http_upgrade;
@@ -583,15 +575,7 @@ At this point, you should be able to access code-server via
        listen [::]:80;
        server_name mydomain.com;
 
-       location / {
-         proxy_pass http://localhost:8080/;
-         proxy_set_header Host $host;
-         proxy_set_header Upgrade $http_upgrade;
-         proxy_set_header Connection upgrade;
-         proxy_set_header Accept-Encoding gzip;
-       }
-       
-       location /static {
+       location ^~ / {
          proxy_pass http://localhost:8080/;
          proxy_set_header Host $host;
          proxy_set_header Upgrade $http_upgrade;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -198,7 +198,7 @@ At this point, you should be able to access code-server via
        listen [::]:80;
        server_name mydomain.com;
 
-       location / {
+       location ^~ / {
          proxy_pass http://localhost:8080/;
          proxy_set_header Host $host;
          proxy_set_header Upgrade $http_upgrade;
@@ -575,7 +575,7 @@ At this point, you should be able to access code-server via
        listen [::]:80;
        server_name mydomain.com;
 
-       location / {
+       location ^~ / {
          proxy_pass http://localhost:8080/;
          proxy_set_header Host $host;
          proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
without `^~`, resources in folders like `/static` cannot be accessed.
So I do this PR. It's a minor one in the doc. So I think there's no need to create an issue for it.