### PR TITLE
resolving error of nodejs

### DIFF
--- a/docs/termux.md
+++ b/docs/termux.md
@@ -17,7 +17,7 @@ run code-server from your Android phone.
 
 1. Install Termux from [F-Droid](https://f-droid.org/en/packages/com.termux/).
 1. Make sure it's up-to-date: `apt update && apt upgrade`
-1. Install required packages: `apt install build-essential python git nodejs nodejs-lts yarn`
+1. Install required packages: `apt install build-essential python git nodejs-lts yarn`
 1. Install code-server: `yarn global add code-server`
 1. Run code-server: `code-server` and navigate to localhost:8080 in your browser
 


### PR DESCRIPTION
to be on save side while installing code-server using yarn on Termux to prevent the following error
```
yarn global add code-server
yarn global v1.22.15
[1/4] Resolving packages...
[2/4] Fetching packages... 
error code-server@3.12.0: The engine "node" is incompatible with this module. Expected version "= 14". Got "16.11.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
```

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
