### PR TITLE
chore(deps): upgrade path-parse in test/yarn.lock

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -22,6 +22,7 @@
     "ansi-regex": "^5.0.1",
     "argon2/@mapbox/node-pre-gyp/tar": "^6.1.9",
     "set-value": "^4.0.1",
-    "tmpl": "^1.0.5"
+    "tmpl": "^1.0.5",
+    "path-parse": "^1.0.7"
   }
 }

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -3467,10 +3467,10 @@ path-key@^3.0.0, path-key@^3.1.0:
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
 
-path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+path-parse@^1.0.6, path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 pend@~1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This PR fixes a minor issue with `path-parse` in `test/yarn.lock`. 

Fixes #4279
