### PR TITLE
Fix watcher not restarting code-server on VS Code compilation

### DIFF
--- a/ci/dev/watch.ts
+++ b/ci/dev/watch.ts
@@ -106,19 +106,10 @@ class Watcher {
       plugin.stderr.on("data", (d) => process.stderr.write(d))
     }
 
-    let startingVscode = false
-    let startedVscode = false
     onLine(vscode, (line, original) => {
       console.log("[vscode]", original)
-      // Wait for watch-client since "Finished compilation" will appear multiple
-      // times before the client starts building.
-      if (!startingVscode && line.includes("Starting watch-client")) {
-        startingVscode = true
-      } else if (startingVscode && line.includes("Finished compilation")) {
-        if (startedVscode) {
-          restartServer()
-        }
-        startedVscode = true
+      if (line.includes("Finished compilation")) {
+        restartServer()
       }
     })
 


### PR DESCRIPTION
The "Starting watch-client" string no longer appears in the latest build
output.  We could look for "Finished compilation with" to avoid
restarting when other tasks restart (since they also include the name
i.e. "Finished compilation extensions with 0 errors") but I figure we
might as well restart code-server when any compilation task completes in
case other tasks include changes that need to be reloaded.