### PR TITLE
Fix /vscode route being shadowed by /

### DIFF
--- a/src/node/routes/index.ts
+++ b/src/node/routes/index.ts
@@ -141,7 +141,7 @@ export const register = async (app: App, args: DefaultedArgs): Promise<Disposabl
   const vsServerRouteHandler = new CodeServerRouteWrapper()
 
   // Note that the root route is replaced in Coder Enterprise by the plugin API.
-  for (const routePrefix of ["/", "/vscode"]) {
+  for (const routePrefix of ["/vscode", "/"]) {
     app.router.use(routePrefix, vsServerRouteHandler.router)
     app.wsRouter.use(routePrefix, vsServerRouteHandler.wsRouter)
   }


### PR DESCRIPTION
This causes / to always take precedence and on the VS Code side we would
see /vscode instead of / so the matching does not work correctly.