### PR TITLE
feat: add test for onLine throw error

### DIFF
--- a/test/unit/node/util.test.ts
+++ b/test/unit/node/util.test.ts
@@ -447,6 +447,28 @@ describe("onLine", () => {
 
     expect(await received).toEqual(expected)
   })
+
+  describe("used with a process missing stdout ", () => {
+    it("should throw an error", async () => {
+      // Initialize a process that does not have stdout.
+      // "If the child was spawned with stdio set to anything
+      // other than 'pipe', then subprocess.stdout will be null."
+      // Source: https://stackoverflow.com/a/46024006/3015595
+      // Other source: https://nodejs.org/api/child_process.html#child_process_subprocess_stdout
+      // NOTE@jsjoeio - I'm not sure if this actually happens though
+      // which is why I have to set proc.stdout = null
+      // a couple lines below.
+      const proc = cp.spawn("node", [], {
+        stdio: "ignore",
+      })
+      const mockCallback = jest.fn()
+
+      expect(() => util.onLine(proc, mockCallback)).toThrowError(/stdout/)
+
+      // Cleanup
+      proc?.kill()
+    })
+  })
 })
 
 describe("escapeHtml", () => {


### PR DESCRIPTION
This PR adds an additional test for the `onLine` util function to cover the scenario where the child.Process passed to the function is missing the `stdout` method. This adds code coverage for [this line](https://github.com/cdr/code-server/blob/main/src/node/util.ts#L36).

## Screenshot

![image](https://user-images.githubusercontent.com/3806031/142920218-73073467-6b2a-480e-afeb-15a6e773d036.png)

## References
- ["If the child was spawned with stdio set to anything other than 'pipe', then subprocess.stdout will be null."](https://stackoverflow.com/a/46024006/3015595)
- [Child Process - subprocess stdout - Node.js docs](https://nodejs.org/api/child_process.html#child_process_subprocess_stdout)
- [Child Process - options `stdio` - Node.js docs](https://nodejs.org/api/child_process.html#child_process_options_stdio)



Fixes N/A
#TestingMondays

Blocked by https://github.com/cdr/code-server/pull/4543