### PR TITLE
chore: add deprecation notice for --link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -56,10 +56,6 @@ code-server.
 We also have an in-depth [setup and
 configuration](https://coder.com/docs/code-server/latest/guide) guide.
 
-## TLS and authentication (beta)
-
-To add TLS and authentication out of the box, use [code-server --link](https://coder.com/docs/code-server/latest/link).
-
 ## Questions?
 
 See answers to [frequently asked

--- a/docs/link.md
+++ b/docs/link.md
@@ -1,6 +1,8 @@
 # code-server --link
 
-Run code-server with the beta flag `--link` and you'll get TLS, authentication, and a dedicated URL
+> Note: This feature is no longer recommended due to instability. Stay tuned for a revised version.
+
+Run code-server with the flag `--link` and you'll get TLS, authentication, and a dedicated URL
 for accessing your IDE out of the box.
 
 ```console

--- a/src/node/cli.ts
+++ b/src/node/cli.ts
@@ -104,9 +104,9 @@ interface Option<T> {
   description?: string
 
   /**
-   * If marked as beta, the option is marked as beta in help.
+   * If marked as deprecated, the option is marked as deprecated in help.
    */
-  beta?: boolean
+  deprecated?: boolean
 }
 
 type OptionType<T> = T extends boolean
@@ -230,7 +230,7 @@ const options: Options<Required<UserProvidedArgs>> = {
       https://hostname-username.cdr.co at which you can easily access your code-server instance.
       Authorization is done via GitHub.
     `,
-    beta: true,
+    deprecated: true,
   },
 }
 
@@ -253,7 +253,7 @@ export const optionDescriptions = (): string[] => {
         .map((line, i) => {
           line = line.trim()
           if (i === 0) {
-            return " ".repeat(widths.long - k.length) + (v.beta ? "(beta) " : "") + line
+            return " ".repeat(widths.long - k.length) + (v.deprecated ? "(deprecated) " : "") + line
           }
           return " ".repeat(widths.long + widths.short + 6) + line
         })


### PR DESCRIPTION
`code-server --link` has not been updated for a while, and some users have reported connection issues with it (see #2734)

While we will continue to host the --link servers, this PR adds a warning that we are not officially maintaining this version of --link. In the future, we will likely release an improved version, using a new architecture and codebase. However, there is no timeline for this.
