### PR TITLE
docs: update sections around VS Code fork

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,22 +2,23 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 # Contributing
 
-- [Requirements](#requirements)
-  - [Linux-specific requirements](#linux-specific-requirements)
-- [Creating pull requests](#creating-pull-requests)
-  - [Commits and commit history](#commits-and-commit-history)
-- [Development workflow](#development-workflow)
-  - [Updates to VS Code](#updates-to-vs-code)
-  - [Build](#build)
-  - [Help](#help)
-- [Test](#test)
-  - [Unit tests](#unit-tests)
-  - [Script tests](#script-tests)
-  - [Integration tests](#integration-tests)
-  - [End-to-end tests](#end-to-end-tests)
-- [Structure](#structure)
-  - [Modifications to VS Code](#modifications-to-vs-code)
-  - [Currently Known Issues](#currently-known-issues)
+- [Contributing](#contributing)
+  - [Requirements](#requirements)
+    - [Linux-specific requirements](#linux-specific-requirements)
+  - [Creating pull requests](#creating-pull-requests)
+    - [Commits and commit history](#commits-and-commit-history)
+  - [Development workflow](#development-workflow)
+    - [Updates to VS Code](#updates-to-vs-code)
+    - [Build](#build)
+    - [Help](#help)
+  - [Test](#test)
+    - [Unit tests](#unit-tests)
+    - [Script tests](#script-tests)
+    - [Integration tests](#integration-tests)
+    - [End-to-end tests](#end-to-end-tests)
+  - [Structure](#structure)
+    - [Modifications to VS Code](#modifications-to-vs-code)
+    - [Currently Known Issues](#currently-known-issues)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -84,23 +85,22 @@ Here are these steps you should follow to get your dev environment setup:
 
 1. `git clone https://github.com/cdr/code-server.git` - Clone `code-server`
 2. `git clone https://github.com/cdr/vscode.git` - Clone `vscode`
-3. `cd vscode && git checkout code-server-v2` - checkout the branch we use (not the default)
-4. `cd vscode && yarn install` - install the dependencies in the `vscode` repo
-5. `cd code-server && yarn install` - install the dependencies in the `code-server` repo
-6. `cd vscode && yarn link` - use `yarn` to create a symlink to the `vscode` repo (`code-oss-dev` package)
-7. `cd code-server && yarn link code-oss-dev --modules-folder vendor/modules` - links your local `vscode` repo (`code-oss-dev` package) inside your local version of code-server
-8. `cd code-server && yarn watch` - this will spin up code-server on localhost:8080 which you can start developing. It will live reload changes to the source.
+3. `cd vscode && yarn install` - install the dependencies in the `vscode` repo
+4. `cd code-server && yarn install` - install the dependencies in the `code-server` repo
+5. `cd vscode && yarn link` - use `yarn` to create a symlink to the `vscode` repo (`code-oss-dev` package)
+6. `cd code-server && yarn link code-oss-dev --modules-folder vendor/modules` - links your local `vscode` repo (`code-oss-dev` package) inside your local version of code-server
+7. `cd code-server && yarn watch` - this will spin up code-server on localhost:8080 which you can start developing. It will live reload changes to the source.
 
 ### Updates to VS Code
 
-If changes are made and merged into `code-server-v2` in the `cdr/vscode` repo, then you'll need to update the version in the `code-server` repo by following these steps:
+If changes are made and merged into `main` in the [`cdr/vscode`](https://github.com/cdr/vscode) repo, then you'll need to update the version in the `code-server` repo by following these steps:
 
 1. Update the package tag listed in `vendor/package.json`:
 
 ```json
 {
   "devDependencies": {
-    "vscode": "cdr/vscode#X.XX.X-code-server"
+    "vscode": "cdr/vscode#<latest-commit-sha>"
   }
 }
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -2,23 +2,22 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 # Contributing
 
-- [Contributing](#contributing)
-  - [Requirements](#requirements)
-    - [Linux-specific requirements](#linux-specific-requirements)
-  - [Creating pull requests](#creating-pull-requests)
-    - [Commits and commit history](#commits-and-commit-history)
-  - [Development workflow](#development-workflow)
-    - [Updates to VS Code](#updates-to-vs-code)
-    - [Build](#build)
-    - [Help](#help)
-  - [Test](#test)
-    - [Unit tests](#unit-tests)
-    - [Script tests](#script-tests)
-    - [Integration tests](#integration-tests)
-    - [End-to-end tests](#end-to-end-tests)
-  - [Structure](#structure)
-    - [Modifications to VS Code](#modifications-to-vs-code)
-    - [Currently Known Issues](#currently-known-issues)
+- [Requirements](#requirements)
+  - [Linux-specific requirements](#linux-specific-requirements)
+- [Creating pull requests](#creating-pull-requests)
+  - [Commits and commit history](#commits-and-commit-history)
+- [Development workflow](#development-workflow)
+  - [Updates to VS Code](#updates-to-vs-code)
+  - [Build](#build)
+  - [Help](#help)
+- [Test](#test)
+  - [Unit tests](#unit-tests)
+  - [Script tests](#script-tests)
+  - [Integration tests](#integration-tests)
+  - [End-to-end tests](#end-to-end-tests)
+- [Structure](#structure)
+  - [Modifications to VS Code](#modifications-to-vs-code)
+  - [Currently Known Issues](#currently-known-issues)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -105,11 +104,11 @@ If changes are made and merged into `main` in the [`cdr/vscode`](https://github.
 }
 ```
 
-1. From the code-server **project root**, run `yarn install`.
+2. From the code-server **project root**, run `yarn install`.
    Then, test code-server locally to make sure everything works.
-1. Check the Node.js version that's used by Electron (which is shipped with VS
+3. Check the Node.js version that's used by Electron (which is shipped with VS
    Code. If necessary, update your version of Node.js to match.
-1. Open a PR
+4. Open a PR
 
 > Watch for updates to
 > `vendor/modules/code-oss-dev/src/vs/code/browser/workbench/workbench.html`. You may need to

--- a/docs/MAINTAINING.md
+++ b/docs/MAINTAINING.md
@@ -19,6 +19,7 @@
     - [Docker](#docker)
     - [Homebrew](#homebrew)
     - [npm](#npm)
+- [Syncing with Upstream VS Code](#syncing-with-upstream-vs-code)
 - [Testing](#testing)
 - [Documentation](#documentation)
   - [Troubleshooting](#troubleshooting)
@@ -126,8 +127,7 @@ the issue.
 
 ### Merge strategies
 
-For most things, we recommend the **squash and merge** strategy. If you're
-updating `lib/vscode`, we suggest using the **rebase and merge** strategy. There
+For most things, we recommend the **squash and merge** strategy. There
 may be times where **creating a merge commit** makes sense as well. Use your
 best judgment. If you're unsure, you can always discuss in the PR with the team.
 
@@ -214,6 +214,18 @@ brew bump-formula-pr --version="${VERSION}" code-server --no-browse --no-audit
 We publish code-server as a npm package [here](https://www.npmjs.com/package/code-server/v/latest).
 
 This is currently automated with the release process.
+
+## Syncing with Upstream VS Code
+
+The VS Code portion of code-server lives under [`cdr/vscode`](https://github.com/cdr/vscode). To update VS Code for code-server, follow these steps:
+
+1. `git checkout -b vscode-update` - Create a new branch locally based off `main`
+2. `git fetch upstream` - Fetch upstream (VS Code)'s latest `main` branch
+3. `git merge upstream/main` - Merge it locally
+   1. If there are merge conflicts, fix them locally
+4. Open a PR merging your branch (`vscode-update`) into `main` and add the code-server review team
+
+Ideally, our fork stays as close to upstream as possible. See the differences between our fork and upstream [here](https://github.com/microsoft/vscode/compare/main...cdr:main).
 
 ## Testing
 


### PR DESCRIPTION
This PR updates our docs around the VS Code fork and syncing with upstream.

Fixes #4533
