### PR TITLE
Remove excessive reloading before VS Code is ready

### DIFF
--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -524,14 +524,7 @@ export const loadAMDModule = async <T>(amdPath: string, exportName: string): Pro
   return module[exportName] as T
 }
 
-export const enum VSCodeCompileStatus {
-  Loading = "Loading",
-  Compiling = "Compiling",
-  Compiled = "Compiled",
-}
-
 export interface CompilationStats {
-  status: VSCodeCompileStatus
   lastCompiledAt: Date
 }
 


### PR DESCRIPTION
The watch script was reloading the web server after every extension
compilation which is not necessary plus VS Code will not even be ready
at that point anyway.

Instead restart when the main compilation is finished.  The string to
match with includes a "with" because otherwise it would match "Finished
compilation extensions" which is not the main compilation task where we
actually need to restart the web server.

I also replaced this.log with console.log because the former does not
include a newline and it appears we want newlines with all
these (otherwise the next log starts on the same line which looks odd).

I removed the cache clean as well because the cache is meant to stay
there to speed up builds.