### PR TITLE
Add separate function for VS Code arguments

### DIFF
--- a/src/node/main.ts
+++ b/src/node/main.ts
@@ -5,7 +5,7 @@ import path from "path"
 import { Disposable } from "../common/emitter"
 import { plural } from "../common/util"
 import { createApp, ensureAddress } from "./app"
-import { AuthType, DefaultedArgs, Feature, UserProvidedArgs } from "./cli"
+import { AuthType, DefaultedArgs, Feature, toVsCodeArgs, UserProvidedArgs } from "./cli"
 import { coderCloudBind } from "./coder_cloud"
 import { commit, version } from "./constants"
 import { register } from "./routes"
@@ -35,14 +35,7 @@ export const runVsCodeCli = async (args: DefaultedArgs): Promise<void> => {
   const spawnCli = await loadAMDModule<CodeServerLib.SpawnCli>("vs/server/remoteExtensionHostAgent", "spawnCli")
 
   try {
-    await spawnCli({
-      ...args,
-      /** Type casting. */
-      "accept-server-license-terms": true,
-      help: !!args.help,
-      version: !!args.version,
-      port: args.port?.toString(),
-    })
+    await spawnCli(await toVsCodeArgs(args))
   } catch (error: any) {
     logger.error("Got error from VS Code", error)
   }

--- a/src/node/routes/vscode.ts
+++ b/src/node/routes/vscode.ts
@@ -3,6 +3,7 @@ import * as express from "express"
 import { WebsocketRequest } from "../../../typings/pluginapi"
 import { logError } from "../../common/util"
 import { isDevMode } from "../constants"
+import { toVsCodeArgs } from "../cli"
 import { ensureAuthenticated, authenticated, redirect } from "../http"
 import { loadAMDModule, readCompilationStats } from "../util"
 import { Router as WsRouter } from "../wsRouter"
@@ -87,15 +88,7 @@ export class CodeServerRouteWrapper {
     )
 
     try {
-      this._codeServerMain = await createVSServer(null, {
-        "connection-token": "0000",
-        "accept-server-license-terms": true,
-        ...args,
-        /** Type casting. */
-        help: !!args.help,
-        version: !!args.version,
-        port: args.port?.toString(),
-      })
+      this._codeServerMain = await createVSServer(null, await toVsCodeArgs(args))
     } catch (createServerError) {
       logError(logger, "CodeServerRouteWrapper", createServerError)
       return next(createServerError)

--- a/test/unit/node/plugin.test.ts
+++ b/test/unit/node/plugin.test.ts
@@ -42,8 +42,6 @@ describe("plugin", () => {
         usingEnvHashedPassword: false,
         "extensions-dir": "",
         "user-data-dir": "",
-        workspace: "",
-        folder: "",
       }
       next()
     }


### PR DESCRIPTION
The problem before was that the pop() caused the open in existing
instance functionality to break because the arguments no longer
contained the workspace or directory (files are left untouched).

We could simply remove the pop() but since `workspace` and `folder` are
not CLI arguments I think it makes sense to handle them in a separate
function which can be called at the point where they are needed.  This
also lets us de-duplicate some logic since we create these arguments in
two spots and lets us skip this logic when we do not need it.

The pop() is still avoided because manipulating a passed-in object
in-place seems like a risky move.  If we really need to do this we
should copy the positional argument array instead.