### PR TITLE
adding option --edge to install latest edge / preview version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ Usage:
   --version X.X.X
       Install a specific version instead of the latest.
 
-  --edge [true | false (default) ]
+  --edge
       Install the latest edge version instead of the latest stable version.
 
   --method [detect | standalone]
@@ -74,7 +74,7 @@ EOF
 }
 
 echo_latest_version() {
-  if [ "${EDGE:-false}" = "true" ]; then
+  if [ "${EDGE-}" ]; then
     version="$(curl -fsSL https://api.github.com/repos/cdr/code-server/releases | awk 'match($0,/.*"html_url": "(.*\/releases\/tag\/.*)".*/)' | head -n 1 | awk -F '"' '{print $4}')"
   else
     # https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c#gistcomment-2758860
@@ -142,6 +142,7 @@ main() {
     OPTIONAL \
     ALL_FLAGS \
     RSH_ARGS \
+    EDGE \
     RSH
 
   ALL_FLAGS=""
@@ -178,11 +179,7 @@ main() {
         VERSION="$(parse_arg "$@")"
         ;;
       --edge)
-        EDGE="$(parse_arg "$@")"
-        shift
-        ;;
-      --edge=*)
-        EDGE="$(parse_arg "$@")"
+        EDGE=1
         ;;
       --rsh)
         RSH="$(parse_arg "$@")"

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ The remote host must have internet access.
 ${not_curl_usage-}
 Usage:
 
-  $arg0 [--dry-run] [--version X.X.X] [--method detect] \
+  $arg0 [--dry-run] [--version X.X.X] [--edge] [--method detect] \
         [--prefix ~/.local] [--rsh ssh] [user@host]
 
   --dry-run
@@ -31,6 +31,9 @@ Usage:
 
   --version X.X.X
       Install a specific version instead of the latest.
+
+  --edge [true | false (default) ]
+      Install the latest edge version instead of the latest stable version.
 
   --method [detect | standalone]
       Choose the installation method. Defaults to detect.
@@ -71,8 +74,12 @@ EOF
 }
 
 echo_latest_version() {
-  # https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c#gistcomment-2758860
-  version="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/cdr/code-server/releases/latest)"
+  if [ "${EDGE:-false}" = "true" ]; then
+    version="$(curl -fsSL https://api.github.com/repos/cdr/code-server/releases | awk 'match($0,/.*"html_url": "(.*\/releases\/tag\/.*)".*/)' | head -n 1 | awk -F '"' '{print $4}')"
+  else
+    # https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c#gistcomment-2758860
+    version="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/cdr/code-server/releases/latest)"
+  fi
   version="${version#https://github.com/cdr/code-server/releases/tag/}"
   version="${version#v}"
   echo "$version"
@@ -169,6 +176,13 @@ main() {
         ;;
       --version=*)
         VERSION="$(parse_arg "$@")"
+        ;;
+      --edge)
+        EDGE="$(parse_arg "$@")"
+        shift
+        ;;
+      --edge=*)
+        EDGE="$(parse_arg "$@")"
         ;;
       --rsh)
         RSH="$(parse_arg "$@")"


### PR DESCRIPTION
Adding option --edge to install latest edge / preview version.

```bash
$ ./install.sh --edge true
```

```bash
$ ./install.sh --edge=true
```
