### PR TITLE
fix: add --clobber to release-github-assets script

### DIFF
--- a/ci/build/release-github-assets.sh
+++ b/ci/build/release-github-assets.sh
@@ -13,7 +13,7 @@ main() {
   download_artifact release-packages ./release-packages
   local assets=(./release-packages/code-server*"$VERSION"*{.tar.gz,.deb,.rpm})
 
-  EDITOR=true gh release upload "v$VERSION" "${assets[@]}"
+  EDITOR=true gh release upload "v$VERSION" "${assets[@]}" --clobber
 }
 
 main "$@"


### PR DESCRIPTION
This PR fixes our `release-github-assets` script. Now if you run it twice, it will overwrite the assets uploaded to a release draft (which is the behavior I believe it previously had).

This is okay to do since the script is run by a developer prepping a release and it is unlikely you would accidentally run this script twice without wanting to overwrite uploaded assets.

Fixes #4602
