### PR TITLE
Fix a command to get the latest version in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,7 @@ echo_latest_version() {
     # https://gist.github.com/lukechilds/a83e1d7127b78fef38c2914c4ececc3c#gistcomment-2758860
     version="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/cdr/code-server/releases/latest)"
   fi
-  version="${version#https://github.com/cdr/code-server/releases/tag/}"
+  version="${version#https://github.com/coder/code-server/releases/tag/}"
   version="${version#v}"
   echo "$version"
 }


### PR DESCRIPTION
We can not get the latest version using `install.sh` as the below.

```shell
$ curl -fsSL https://code-server.dev/install.sh | sh
Ubuntu 20.04.3 LTS
Installing vhttps://github.com/coder/code-server/releases/tag/v3.12.0 of the amd64 deb package from GitHub.

+ mkdir -p ~/.cache/code-server
+ curl -#fL -o ~/.cache/code-server/code-server_https://github.com/coder/code-server/releases/tag/v3.12.0_amd64.deb.incomplete -C - https://github.com/cdr/code-server/releases/download/vhttps://github.com/coder/code-server/releases/tag/v3.12.0/code-server_https://github.com/coder/code-server/releases/tag/v3.12.0_amd64.deb
curl: (22) The requested URL returned error: 404 Not Found############## 100.0%##O#-#
```

It looks like [this](https://github.com/coder/code-server/blob/73e0b79d7f33eba94108363a7b38e2b9b77492d2/install.sh#L83) can not get a version out of `https://github.com/coder/code-server/releases/tag/v3.12.0`.

```shell
$ version="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/cdr/code-server/releases/latest)"
$ echo "${version#https://github.com/cdr/code-server/releases/tag/}"
https://github.com/coder/code-server/releases/tag/v3.12.0
```

So, this PR fixes a command to get the latest version in `install.sh`.
Also, I have confirmed that it works with the following.

```shell
$ version="$(curl -fsSLI -o /dev/null -w "%{url_effective}" https://github.com/cdr/code-server/releases/latest)"
$ echo "${version#https://github.com/coder/code-server/releases/tag/}"
v3.12.0
```

Fixes #4634 
