### PR TITLE
Adding information on using PWA with Firefox

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -88,6 +88,12 @@ app (PWA):
 1. Start the editor
 2. Click the **plus** icon in the URL toolbar to install the PWA
 
+If you use Firefox, you can use the appropriate extension to install PWA.
+
+1. Go to the installation [website](https://addons.mozilla.org/en-US/firefox/addon/pwas-for-firefox/) of the add-on
+2. Add the add-on to Firefox
+3. Follow the os-specific instructions on how to install the runtime counterpart
+
 For other browsers, you'll have to remap keybindings for shortcuts to work.
 
 ## Why can't code-server use Microsoft's extension marketplace?


### PR DESCRIPTION
Hello everybody,

this really is just a minor addition to the docs of the project.
In order to make keybindings work with code-server, you can install PWA to use the web interface as if it was running natively.
The tutorial provided by the documentation only covers the Chrome installation, so I thought I'd add the installation procedure for Firefox.

I didn't create an issue because I don't  think this really is anything of greater concern 😅 

Cheers,
Felix
