### PR TITLE
Fix clipboard access issue for VIM extension in safari

### DIFF
--- a/patches/clipboard.diff
+++ b/patches/clipboard.diff
@@ -137,18 +137,20 @@ Index: code-server/lib/vscode/src/vs/workbench/services/clipboard/browser/clipbo
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/workbench/services/clipboard/browser/clipboardService.ts
 +++ code-server/lib/vscode/src/vs/workbench/services/clipboard/browser/clipboardService.ts
-@@ -15,19 +15,36 @@ import { IWorkbenchEnvironmentService }
+@@ -15,19 +15,38 @@ import { IWorkbenchEnvironmentService }
  import { ILogService } from '../../../../platform/log/common/log.js';
  import { ILayoutService } from '../../../../platform/layout/browser/layoutService.js';
  import { getActiveWindow } from '../../../../base/browser/dom.js';
 +import { isSafari } from '../../../../base/browser/browser.js';
 +import { IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
++import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
  
  export class BrowserClipboardService extends BaseBrowserClipboardService {
  
  	constructor(
  		@INotificationService private readonly notificationService: INotificationService,
 +		@IContextKeyService	private readonly contextKeyService: IContextKeyService,
++		@ICodeEditorService private readonly codeEditorService: ICodeEditorService,
  		@IOpenerService private readonly openerService: IOpenerService,
  		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
  		@ILogService logService: ILogService,
@@ -158,7 +160,7 @@ Index: code-server/lib/vscode/src/vs/workbench/services/clipboard/browser/clipbo
 +		if (isSafari) {
 +			window.addEventListener('keydown', event => {
 +				if (
-+					(event.key.toLowerCase() === 'p' && this.contextKeyService.getContextKeyValue('vim.mode') === 'Normal') ||
++					(event.key.toLowerCase() === 'p' && this.contextKeyService.getContextKeyValue('vim.mode') === 'Normal' && this.codeEditorService.getActiveCodeEditor()?.hasTextFocus()) ||
 +					(event.key === 'v' && (event.ctrlKey || event.metaKey) && this.contextKeyService.getContextKeyValue('vim.mode') === 'SearchInProgressMode')
 +				) {
 +					this.lastClipboardTextContent = navigator.clipboard.readText()
@@ -174,7 +176,7 @@ Index: code-server/lib/vscode/src/vs/workbench/services/clipboard/browser/clipbo
  	override async writeText(text: string, type?: string): Promise<void> {
  		if (!!this.environmentService.extensionTestsLocationURI && typeof type !== 'string') {
  			type = 'vscode-tests'; // force in-memory clipboard for tests to avoid permission issues
-@@ -46,6 +63,15 @@ export class BrowserClipboardService ext
+@@ -46,6 +65,15 @@ export class BrowserClipboardService ext
  		}
  
  		try {


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

I typically use code-server in Safari with the VIM extension, but I've encountered issues with clipboard functionality due to the underlying VSCode architecture. After some exploration, I found a way to improve the clipboard experience in Safari: when certain events that can read the clipboard (such as pressing 'p' or 'ctrl+v') are triggered, the clipboard content is read into memory, and subsequent read requests within a short time window will return the cached content instead of reading from the clipboard
