### PR TITLE
Fix Open VSX marketplace URL gallery path issue

### DIFF
--- a/patches/marketplace.diff
+++ b/patches/marketplace.diff
@@ -19,7 +19,7 @@ Index: code-server/lib/vscode/src/vs/platform/product/common/product.ts
 ===================================================================
 --- code-server.orig/lib/vscode/src/vs/platform/product/common/product.ts
 +++ code-server/lib/vscode/src/vs/platform/product/common/product.ts
-@@ -49,6 +49,16 @@ else if (globalThis._VSCODE_PRODUCT_JSON
+@@ -49,6 +49,17 @@ else if (globalThis._VSCODE_PRODUCT_JSON
  			version: pkg.version
  		});
  	}
@@ -28,6 +28,7 @@ Index: code-server/lib/vscode/src/vs/platform/product/common/product.ts
 +		extensionsGallery: env.EXTENSIONS_GALLERY ? JSON.parse(env.EXTENSIONS_GALLERY) : (product.extensionsGallery || {
 +			serviceUrl: "https://open-vsx.org/vscode/gallery",
 +			itemUrl: "https://open-vsx.org/vscode/item",
++			extensionUrlTemplate: "https://open-vsx.org/vscode/gallery/{publisher}/{name}/latest",
 +			resourceUrlTemplate: "https://open-vsx.org/vscode/asset/{publisher}/{name}/{version}/Microsoft.VisualStudio.Code.WebResources/{path}",
 +			controlUrl: "",
 +			recommendationsUrl: "",


### PR DESCRIPTION
Description
This PR fixes a URL path issue in the Open VSX marketplace integration that was causing incorrect redirects.

Problem
vscode extension gallery was generating incorrect URLs with an extra /vscode segment:

❌ Incorrect: https://open-vsx.org/vscode/gallery/vscode/eamodio/gitlens/latest
✅ Correct: https://open-vsx.org/vscode/gallery/eamodio/gitlens/latest
The incorrect URL format was causing redirects to http://open-vsx.org/error instead of properly resolving extension resources.

Changes
Fixed the extension latest version URI template in extensionGalleryManifestService.ts by removing the redundant /vscode segment