### PR TITLE
Improve helm chart

### DIFF
--- a/ci/helm-chart/templates/deployment.yaml
+++ b/ci/helm-chart/templates/deployment.yaml
@@ -3,10 +3,7 @@ kind: Deployment
 metadata:
   name: {{ include "code-server.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "code-server.name" . }}
-    helm.sh/chart: {{ include "code-server.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "code-server.labels" . | nindent 4 }}
   {{- if .Values.annotations }}
   annotations: {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
@@ -16,13 +13,11 @@ spec:
     type: Recreate
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ include "code-server.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "code-server.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: {{ include "code-server.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "code-server.selectorLabels" . | nindent 8 }}
       {{- if .Values.podAnnotations }}
       annotations: {{- toYaml .Values.podAnnotations | nindent 8 }}
       {{- end }}
@@ -130,11 +125,11 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
           readinessProbe:
             httpGet:
-              path: /
+              path: /healthz
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/ci/helm-chart/templates/pvc.yaml
+++ b/ci/helm-chart/templates/pvc.yaml
@@ -9,10 +9,7 @@ metadata:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
-    app.kubernetes.io/name: {{ include "code-server.name" . }}
-    helm.sh/chart: {{ include "code-server.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "code-server.labels" . | nindent 4 }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}

--- a/ci/helm-chart/templates/secrets.yaml
+++ b/ci/helm-chart/templates/secrets.yaml
@@ -6,10 +6,7 @@ metadata:
   annotations:
     "helm.sh/hook": "pre-install"
   labels:
-    app.kubernetes.io/name: {{ include "code-server.name" . }}
-    helm.sh/chart: {{ include "code-server.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "code-server.labels" . | nindent 4 }}
 type: Opaque
 data:
   {{- if .Values.password }}

--- a/ci/helm-chart/templates/service.yaml
+++ b/ci/helm-chart/templates/service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   name: {{ include "code-server.fullname" . }}
   labels:
-    app.kubernetes.io/name: {{ include "code-server.name" . }}
-    helm.sh/chart: {{ include "code-server.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "code-server.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/ci/helm-chart/templates/serviceaccount.yaml
+++ b/ci/helm-chart/templates/serviceaccount.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app.kubernetes.io/name: {{ include "code-server.name" . }}
-    helm.sh/chart: {{ include "code-server.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "code-server.labels" . | nindent 4 }}
   name: {{ template "code-server.serviceAccountName" . }}
 {{- end -}}

--- a/ci/helm-chart/templates/tests/test-connection.yaml
+++ b/ci/helm-chart/templates/tests/test-connection.yaml
@@ -3,16 +3,13 @@ kind: Pod
 metadata:
   name: "{{ include "code-server.fullname" . }}-test-connection"
   labels:
-    app.kubernetes.io/name: {{ include "code-server.name" . }}
-    helm.sh/chart: {{ include "code-server.chart" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "code-server.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": test-success
+    "helm.sh/hook": test
 spec:
   containers:
     - name: wget
       image: busybox
       command: ['wget']
-      args:  ['{{ include "code-server.fullname" . }}:{{ .Values.service.port }}']
+      args:  ['{{ include "code-server.fullname" . }}:{{ .Values.service.port }}/healthz']
   restartPolicy: Never


### PR DESCRIPTION
<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->
Minor improvement of the helm chart.

- Reuses the label templates
- Uses /healthz endpoint for health checks and test (without that [ct install](https://github.com/helm/chart-testing) is failing)

I can also update the Github action and add chart testing besides linting.