### PR TITLE
Add Dockerfile and railway.toml for Railway deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:12
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    dumb-init \
+    git \
+    git-lfs \
+    htop \
+    locales \
+    man-db \
+    nano \
+    openssh-client \
+    procps \
+    sudo \
+    vim-tiny \
+    wget \
+    zsh \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/*
+
+# Set locale
+RUN sed -i "s/# en_US.UTF-8/en_US.UTF-8/" /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8
+
+# Install code-server
+RUN curl -fsSL https://code-server.dev/install.sh | sh
+
+# Create coder user
+RUN adduser --gecos '' --disabled-password coder \
+  && echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+
+USER coder
+WORKDIR /home/coder
+
+# Railway sets PORT; default to 8080
+ENV PORT=8080
+
+# Use shell form so $PORT is expanded at runtime
+ENTRYPOINT ["/bin/sh", "-c", "exec dumb-init code-server --bind-addr 0.0.0.0:${PORT}"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+healthcheckPath = "/healthz"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
Enables one-click deployment to Railway for remote code-server access from mobile devices. Uses the official install script, binds to the Railway-provided PORT, and includes a health check endpoint.

https://claude.ai/code/session_01Famw4SjSWr4tECPrC6Z3ef

<!--
Please link to the issue this PR solves.
If there is no existing issue, please first create one unless the fix is minor.

Please make sure the base of your PR is the default branch!
-->

Fixes #
