### PR TITLE
fix: remove config file path from login page

### DIFF
--- a/src/node/i18n/locales/en.json
+++ b/src/node/i18n/locales/en.json
@@ -2,7 +2,7 @@
   "LOGIN_TITLE": "{{app}} login",
   "LOGIN_BELOW": "Please log in below.",
   "WELCOME": "Welcome to {{app}}",
-  "LOGIN_PASSWORD": "Check the config file at {{configFile}} for the password.",
+  "LOGIN_PASSWORD": "Check the config file for the password.",
   "LOGIN_USING_ENV_PASSWORD": "Password was set from $PASSWORD.",
   "LOGIN_USING_HASHED_PASSWORD": "Password was set from $HASHED_PASSWORD.",
   "SUBMIT": "SUBMIT",

--- a/src/node/i18n/locales/ja.json
+++ b/src/node/i18n/locales/ja.json
@@ -2,7 +2,7 @@
   "LOGIN_TITLE": "{{app}} ログイン",
   "LOGIN_BELOW": "以下によりログインしてください。",
   "WELCOME": "ようこそ {{app}} へ！",
-  "LOGIN_PASSWORD": "パスワードは設定ファイル（ {{configFile}} ）を確認してください。",
+  "LOGIN_PASSWORD": "パスワードは設定ファイルを確認してください。",
   "LOGIN_USING_ENV_PASSWORD": "パスワードは環境変数 $PASSWORD で設定されています。",
   "LOGIN_USING_HASHED_PASSWORD": "パスワードは環境変数 $HASHED_PASSWORD で設定されています。",
   "SUBMIT": "実行",

--- a/src/node/i18n/locales/th.json
+++ b/src/node/i18n/locales/th.json
@@ -2,7 +2,7 @@
   "LOGIN_TITLE": "เข้าสู่ระบบ {{app}}",
   "LOGIN_BELOW": "กรุณาเข้าสู่ระบบด้านล่าง",
   "WELCOME": "ยินดีต้อนรับสู่ {{app}}",
-  "LOGIN_PASSWORD": "ตรวจสอบไฟล์กำหนดค่าที่ {{configFile}} เพื่อดูรหัสผ่าน",
+  "LOGIN_PASSWORD": "ตรวจสอบไฟล์กำหนดค่าเพื่อดูรหัสผ่าน",
   "LOGIN_USING_ENV_PASSWORD": "รหัสผ่านถูกกำหนดเป็น $PASSWORD",
   "LOGIN_USING_HASHED_PASSWORD": "รรหัสผ่านถูกกำหนดเป็น $HASHED_PASSWORD",
   "SUBMIT": "ส่ง",

--- a/src/node/i18n/locales/ur.json
+++ b/src/node/i18n/locales/ur.json
@@ -2,7 +2,7 @@
   "LOGIN_TITLE": "{{app}} لاگ ان کریں",
   "LOGIN_BELOW": "براہ کرم نیچے لاگ ان کریں۔",
   "WELCOME": "میں خوش آمدید {{app}}",
-  "LOGIN_PASSWORD": "پاس ورڈ کے لیے {{configFile}} پر کنفگ فائل چیک کریں۔",
+  "LOGIN_PASSWORD": "پاس ورڈ کے لیے کنفگ فائل چیک کریں۔",
   "LOGIN_USING_ENV_PASSWORD": "پاس ورڈ $PASSWORD سے سیٹ کیا گیا تھا۔",
   "LOGIN_USING_HASHED_PASSWORD": "پاس ورڈ $HASHED_PASSWORD سے سیٹ کیا گیا تھا۔",
   "SUBMIT": "جمع کرائیں",

--- a/src/node/i18n/locales/zh-cn.json
+++ b/src/node/i18n/locales/zh-cn.json
@@ -2,7 +2,7 @@
   "LOGIN_TITLE": "{{app}} 登录",
   "LOGIN_BELOW": "请在下面登录。",
   "WELCOME": "欢迎来到 {{app}}",
-  "LOGIN_PASSWORD": "查看配置文件 {{configFile}} 中的密码。",
+  "LOGIN_PASSWORD": "查看配置文件中的密码。",
   "LOGIN_USING_ENV_PASSWORD": "密码在 $PASSWORD 中设置。",
   "LOGIN_USING_HASHED_PASSWORD": "密码在 $HASHED_PASSWORD 中设置。",
   "SUBMIT": "提交",

--- a/src/node/routes/login.ts
+++ b/src/node/routes/login.ts
@@ -32,7 +32,7 @@ const getRoot = async (req: Request, error?: Error): Promise<string> => {
   const welcomeText = req.args["welcome-text"] || (i18n.t("WELCOME", { app: req.args["app-name"] }) as string)
 
   // Determine password message using i18n
-  let passwordMsg = i18n.t("LOGIN_PASSWORD", { configFile: req.args.config })
+  let passwordMsg = i18n.t("LOGIN_PASSWORD")
   if (req.args.usingEnvPassword) {
     passwordMsg = i18n.t("LOGIN_USING_ENV_PASSWORD")
   } else if (req.args.usingEnvHashedPassword) {


### PR DESCRIPTION
Fixes #7643

The login page displayed the full config file path (e.g.
`/home/username/.config/code-server/config.yaml`), exposing the
username and system layout to anyone who can see the page.

The path is already printed in the CLI output at startup, so
showing it on the login page is unnecessary. Removed the
`{{configFile}}` interpolation from all locale files.