### PR TITLE
Make replicaCount optional (skip rendering when null)

### DIFF
--- a/ci/helm-chart/templates/deployment.yaml
+++ b/ci/helm-chart/templates/deployment.yaml
@@ -8,7 +8,9 @@ metadata:
   annotations: {{- toYaml .Values.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.replicaCount | default 1 }}
+  {{- if ne .Values.replicaCount nil }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
   strategy:
     type: Recreate
   selector:


### PR DESCRIPTION
Currently, `replicas` is always rendered in the Deployment manifest based on `.Values.replicaCount`, which defaults to `1`.

This makes it impossible to delegate replica management to other mechanisms (e.g., HPA, KEDA) by unsetting the value.

This change allows:
- Using HorizontalPodAutoscaler without conflicting static replica settings
- Explicitly disabling fixed replica counts
 
#### Backward Compatibility
- No change for existing users unless they explicitly set `replicaCount: null`
- Default behavior (`1`) remains unchanged by `values.yaml`

#### Notes

We intentionally avoid a simple `if .Values.replicaCount` check to ensure `0` remains a valid value.